### PR TITLE
Fix/refine-tagging-logic

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,12 +24,14 @@ jobs:
           SHORT_SHA=$(git rev-parse --short HEAD)
           TAG1="dev"
           TAG2="commit-$SHORT_SHA"
+
           if [[ "${{ steps.check-version.outputs.is_valid }}" == 'true' ]]; then
             TAG1="latest"
             TAG2="${{ steps.check-version.outputs.full_without_prefix }}"
           fi
-          echo "::set-output name=tag1::$TAG1"
-          echo "::set-output name=tag2::$TAG2"
+
+          echo "TAG1=$TAG1" >> $GITHUB_ENV
+          echo "TAG2=$TAG2" >> $GITHUB_ENV
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,18 +11,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Check Version Format in Tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: nowsprinting/check-version-format-action@v4.0.2
+        id: check-version
+        with:
+          prefix: 'v'
+
       - name: Set tag
         id: set-tag
         run: |
           SHORT_SHA=$(git rev-parse --short HEAD)
-          TAG_VERSION=$(echo ${{ github.ref }} | sed 's,refs/tags/v,,g')
-          if [[ "${{ github.ref }}" == "refs/tags/v*" ]]; then
-            echo "::set-output name=tag1::latest"
-            echo "::set-output name=tag2::$TAG_VERSION"
-          else
-            echo "::set-output name=tag1::dev"
-            echo "::set-output name=tag2::commit-$SHORT_SHA"
+          TAG1="dev"
+          TAG2="commit-$SHORT_SHA"
+          if [[ "${{ steps.check-version.outputs.is_valid }}" == 'true' ]]; then
+            TAG1="latest"
+            TAG2="${{ steps.check-version.outputs.full_without_prefix }}"
           fi
+          echo "::set-output name=tag1::$TAG1"
+          echo "::set-output name=tag2::$TAG2"
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,9 +15,10 @@ jobs:
         id: set-tag
         run: |
           SHORT_SHA=$(git rev-parse --short HEAD)
-          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+          TAG_VERSION=$(echo ${{ github.ref }} | sed 's,refs/tags/v,,g')
+          if [[ "${{ github.ref }}" == "refs/tags/v*" ]]; then
             echo "::set-output name=tag1::latest"
-            echo "::set-output name=tag2::commit-$SHORT_SHA"
+            echo "::set-output name=tag2::$TAG_VERSION"
           else
             echo "::set-output name=tag1::dev"
             echo "::set-output name=tag2::commit-$SHORT_SHA"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -41,8 +41,8 @@ jobs:
             mtr.devops.telekom.de/caas/py-kube-downscaler
             ghcr.io/caas-team/py-kube-downscaler
           tags: |
-            ${{ steps.set-tag.outputs.tag1 }}
-            ${{ steps.set-tag.outputs.tag2 }}
+            ${{ env.TAG1 }}
+            ${{ env.TAG2 }}
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@main


### PR DESCRIPTION
## Motivation

This PR addresses the issue of automatic "latest" tagging for main branch commits, which could mistakenly promote unstable builds into production. The update ensures that the "latest" tag is only applied to stable, versioned releases. 

- Solves: #19

## Changes

- Removed automatic "latest" tagging from main branch commits.
- "Latest" tag now only applies to new release tags.
- Added logic to extract version numbers from git tags for Docker image tagging.

## TODO

- [x] I've assigned myself to this PR.