### PR TITLE
Remove the whitespace in the join for the kube-downscaler ConfigMap Helm template.

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -4,4 +4,4 @@ metadata:
   name: {{ include "py-kube-downscaler.name" . }}
 data:
   # downscale for non-work hours
-  EXCLUDE_NAMESPACES: "{{- join ", " .Values.excludedNamespaces }}"
+  EXCLUDE_NAMESPACES: "{{- join "," .Values.excludedNamespaces }}"


### PR DESCRIPTION
This fixes #26

## Motivation

To fix #26 

---

## Changes

Simply removing the trailing white-space in the `Helm join()` in the `kube-downscaler` `ConfigMap Helm Template` file. The white-space makes namespace exclusions go haywire. This is, at least as far as I can interpret, because of [LOC78 in main.py](https://github.com/caas-team/py-kube-downscaler/blob/main/kube_downscaler/main.py#L78). Where the `Python re lib` is used. It also splits the string, and `split(",")` seems **NOT** to work with entries being e.g.: `namespacea, namespaceb, namespacec` and so on.

## Tests done

1. I manually edited the `EXCLUDE_NAMESPACES` list in the `ConfigMap`. Simply removed every white-space after each `namespace`.
2. Restarted the `Kube-downscaler Pod` by deleting it
3. Watched it work

E.g. in the log.

```text
2024-05-05 20:40:52,762 DEBUG: Namespace haproxy-system was excluded (exclusion list regex matches)
....
....
```

A line for each `namespace` to be excluded. This with the `kube-downscaler` in `DEBUG` mode.

Thank you and of course ask and inquire me for more info if needed. However, I think this should be pretty clear.