### PR TITLE
New Feature - Downscaling DaemonSet 

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Available command line options:
 `--include-resources`
 
 :   Downscale resources of this kind as comma separated list.
-    \[deployments, statefulsets, stacks, horizontalpodautoscalers, rollouts, scaledobjects\]
+    \[deployments, statefulsets, stacks, horizontalpodautoscalers, cronjobs, daemonsets, rollouts, scaledobjects\]
     (default: deployments)
 
 `--grace-period`

--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -22,6 +22,7 @@ rules:
   resources:
     - deployments
     - statefulsets
+    - daemonsets
   verbs:
     - get
     - watch

--- a/kube_downscaler/cmd.py
+++ b/kube_downscaler/cmd.py
@@ -10,6 +10,7 @@ VALID_RESOURCES = frozenset(
         "horizontalpodautoscalers",
         "rollouts",
         "scaledobjects",
+        "daemonsets"
     ]
 )
 

--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -114,12 +114,8 @@ def ignore_if_labels_dont_match(
     resource: NamespacedAPIObject, labels: FrozenSet[Pattern]
 ) -> bool:
 
-    # if matching_labels contains empty string all resources are considered in the scaling process
-    first_element = next(iter(labels), None)
-    first_element_str = first_element.pattern
-
-    if first_element_str == "":
-        logger.debug("Matching_labels arg set to empty string: all resources are considered in the scaling process")
+    # For backwards compatibility, if there is no label filter, we don't ignore anything
+    if not any(label.pattern for label in labels):
         return False
 
     # Ignore resources whose labels do not match the set of input labels

--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -237,24 +237,6 @@ def scale_up(
         logger.info(
             f"Unpausing {resource.kind} {resource.namespace}/{resource.name} (uptime: {uptime}, downtime: {downtime}"
         )
-    elif resource.kind == "DaemonSet":
-        if "nodeSelector" in resource.obj["spec"]["template"]["spec"]:
-            kube_downscaler_node_selector_dict = resource.obj["spec"]["template"]["spec"]["nodeSelector"]
-        else:
-            kube_downscaler_node_selector_dict = None
-        if kube_downscaler_node_selector_dict is None:
-            suspended = False
-        else:
-            if "kube-downscaler-non-existent" in kube_downscaler_node_selector_dict:
-                suspended = True
-            else:
-                suspended = False
-        replicas = 0 if suspended else 1
-        state = "suspended" if suspended else "not suspended"
-        original_state = "suspended" if original_replicas == 0 else "not suspended"
-        logger.debug(
-            f"{resource.kind} {resource.namespace}/{resource.name} is {state} (original: {original_state}, uptime: {uptime})"
-        )
     else:
         resource.replicas = original_replicas
         logger.info(

--- a/tests/test_autoscale_resource.py
+++ b/tests/test_autoscale_resource.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from datetime import datetime
 from datetime import timezone
 from unittest.mock import MagicMock
@@ -47,6 +48,7 @@ def test_swallow_exception(monkeypatch, resource, caplog):
         forced_downtime=False,
         dry_run=True,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 1
     resource.update.assert_not_called()
@@ -77,6 +79,7 @@ def test_swallow_exception_with_event(monkeypatch, resource, caplog):
         dry_run=True,
         now=now,
         enable_events=True,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 1
     resource.update.assert_not_called()
@@ -102,6 +105,7 @@ def test_exclude(resource):
         forced_downtime=False,
         dry_run=True,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 1
     resource.update.assert_not_called()
@@ -126,6 +130,7 @@ def test_exclude_until_invalid_time(resource, caplog):
         forced_downtime=False,
         dry_run=True,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 0
     assert resource.annotations[ORIGINAL_REPLICAS_ANNOTATION] == "1"
@@ -156,6 +161,7 @@ def test_dry_run(resource):
         now=now,
         grace_period=0,
         downtime_replicas=0,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 0
     assert resource.annotations[ORIGINAL_REPLICAS_ANNOTATION] == "1"
@@ -182,6 +188,7 @@ def test_grace_period(resource):
         dry_run=False,
         now=now,
         grace_period=300,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 1
     assert resource.annotations == {}
@@ -205,6 +212,7 @@ def test_downtime_always(resource):
         forced_downtime=False,
         dry_run=False,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 0
     resource.update.assert_called_once()
@@ -228,6 +236,7 @@ def test_downtime_interval(resource):
         forced_downtime=False,
         dry_run=False,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 0
     resource.update.assert_called_once()
@@ -251,6 +260,7 @@ def test_forced_uptime(resource):
         forced_downtime=False,
         dry_run=False,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 1
     resource.update.assert_not_called()
@@ -273,6 +283,7 @@ def test_forced_downtime(resource):
         forced_downtime=True,
         dry_run=False,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 0
     resource.update.assert_called_once()
@@ -293,6 +304,7 @@ def test_autoscale_bad_resource():
             forced_downtime=False,
             dry_run=False,
             now=now,
+            matching_labels=frozenset([re.compile("")]),
         )
         raise AssertionError("Failed to error out with a bad resource")
     except Exception:
@@ -319,6 +331,7 @@ def test_scale_up(resource):
         forced_downtime=False,
         dry_run=False,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 3
     resource.update.assert_called_once()
@@ -346,6 +359,7 @@ def test_scale_up_downtime_replicas_annotation(resource):
         dry_run=False,
         now=now,
         downtime_replicas=1,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 1
     resource.update.assert_called_once()
@@ -368,6 +382,7 @@ def test_downtime_replicas_annotation_invalid(resource):
         forced_downtime=False,
         dry_run=False,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 2
     resource.update.assert_not_called()
@@ -390,6 +405,7 @@ def test_downtime_replicas_annotation_valid(resource):
         forced_downtime=False,
         dry_run=False,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 1
     resource.update.assert_called_once()
@@ -413,6 +429,7 @@ def test_downtime_replicas_invalid(resource):
         dry_run=False,
         now=now,
         downtime_replicas="x",
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 2
     resource.update.assert_not_called()
@@ -435,6 +452,7 @@ def test_downtime_replicas_valid(resource):
         dry_run=False,
         now=now,
         downtime_replicas=1,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 1
     resource.update.assert_called_once()
@@ -464,6 +482,7 @@ def test_set_annotation():
         forced_downtime=False,
         dry_run=False,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     api.patch.assert_called_once()
     patch_data = json.loads(api.patch.call_args[1]["data"])
@@ -495,6 +514,7 @@ def test_downscale_always(resource):
         forced_downtime=False,
         dry_run=False,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 0
     resource.update.assert_called_once()
@@ -518,6 +538,7 @@ def test_downscale_period(resource):
         forced_downtime=False,
         dry_run=False,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 0
     resource.update.assert_called_once()
@@ -541,6 +562,7 @@ def test_downscale_period_overlaps(resource):
         forced_downtime=False,
         dry_run=False,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 2
     resource.update.assert_not_called()
@@ -563,6 +585,7 @@ def test_downscale_period_not_match(resource):
         forced_downtime=False,
         dry_run=False,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 2
     resource.update.assert_not_called()
@@ -587,6 +610,7 @@ def test_downscale_period_resource_overrides_never(resource):
         forced_downtime=False,
         dry_run=False,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 0
     resource.update.assert_called_once()
@@ -611,6 +635,7 @@ def test_downscale_period_resource_overrides_namespace(resource):
         forced_downtime=False,
         dry_run=False,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 0
     resource.update.assert_called_once()
@@ -636,6 +661,7 @@ def test_upscale_period_resource_overrides_never(resource):
         forced_downtime=False,
         dry_run=False,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 1
     resource.upd
@@ -661,6 +687,7 @@ def test_upscale_period_resource_overrides_namespace(resource):
         forced_downtime=False,
         dry_run=False,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 1
     resource.upd
@@ -692,6 +719,7 @@ def test_downscale_stack_deployment_ignored():
         forced_downtime=False,
         dry_run=False,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 1
     resource.update.assert_not_called()
@@ -716,6 +744,7 @@ def test_downscale_replicas_not_zero(resource):
         dry_run=False,
         now=now,
         downtime_replicas=1,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 1
     assert resource.annotations[ORIGINAL_REPLICAS_ANNOTATION] == "3"
@@ -730,6 +759,7 @@ def test_downscale_replicas_not_zero(resource):
         dry_run=False,
         now=now,
         downtime_replicas=1,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert resource.replicas == 1
     assert resource.annotations[ORIGINAL_REPLICAS_ANNOTATION] == "3"
@@ -763,6 +793,7 @@ def test_downscale_stack_with_autoscaling():
         forced_downtime=False,
         dry_run=True,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert stack.replicas == 0
 
@@ -796,6 +827,7 @@ def test_upscale_stack_with_autoscaling():
         dry_run=True,
         enable_events=False,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert stack.obj["spec"]["replicas"] is None
     assert stack.replicas == 4
@@ -828,6 +860,7 @@ def test_downscale_hpa_with_autoscaling():
         forced_downtime=False,
         dry_run=True,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert hpa.obj["spec"]["minReplicas"] == 1
     assert hpa.obj["metadata"]["annotations"][ORIGINAL_REPLICAS_ANNOTATION] == str(4)
@@ -862,6 +895,7 @@ def test_upscale_hpa_with_autoscaling():
         forced_downtime=False,
         dry_run=True,
         now=now,
+        matching_labels=frozenset([re.compile("")]),
     )
     assert hpa.obj["spec"]["minReplicas"] == 4
     assert hpa.obj["metadata"]["annotations"][ORIGINAL_REPLICAS_ANNOTATION] is None

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -19,6 +19,6 @@ def test_check_include_resources_invalid():
     with pytest.raises(Exception) as excinfo:
         check_include_resources("deployments,foo")
     assert (
-        "--include-resources argument should contain a subset of [cronjobs, deployments, horizontalpodautoscalers, rollouts, scaledobjects, stacks, statefulsets]"
+        "--include-resources argument should contain a subset of [cronjobs, daemonsets, deployments, horizontalpodautoscalers, rollouts, scaledobjects, stacks, statefulsets]"
         in str(excinfo.value)
     )

--- a/tests/test_ignore_if_labels_dont_match.py
+++ b/tests/test_ignore_if_labels_dont_match.py
@@ -16,10 +16,9 @@ def resource():
     deployment = Deployment(api_mock, labels_mock)
     yield deployment
 
-
 def test_dont_ignore_if_no_labels(resource):
     # for backwards compatibility, if no labels are specified, don't ignore the resource
-    assert not ignore_if_labels_dont_match(resource, frozenset())
+    assert not ignore_if_labels_dont_match(resource, frozenset([re.compile("")]))
 
 
 def test_dont_ignore_if_labels_match(resource):


### PR DESCRIPTION
Hi Everyone,

Today I added to the project the option to Downscale DaemonSets! DaemonSets are usually not among the highest priorities when scaling down the cluster during non-working hours because they often support vital processes for the cluster (logging, monitoring and so on) however, it may be the case that not all DaemonSets are needed for applications that remain active during non-working hours. Turning off these DaemonSets could be very convenient especially when combined with using Karpenter

The new feature acts in this way:

Downtime Hours: Add to the DaemonSet a Node Selector that cannot be satisfied called `kube-downscaler-non-existent=true
`Uptime Hours: Remove from the DaemonSet the `kube-downscaler-non-existent=true` Node Selector

## Changes

added the logic explained above inside the scaler.py, changed the cmd.py in order to accept daemonsets as input, refactored documentation

## Tests done

added two tests for this feature inside test_scaler.py

## TODO

- [x] I've assigned myself to this PR
