### PR TITLE
Fixed KubeDownscaler Ignoring Keda ScaledObjects if the "paused-replicas" annotation is already present

### DIFF
--- a/kube_downscaler/resources/keda.py
+++ b/kube_downscaler/resources/keda.py
@@ -10,8 +10,16 @@ class ScaledObject(NamespacedAPIObject):
     kind = "ScaledObject"
 
     keda_pause_annotation = "autoscaling.keda.sh/paused-replicas"
+    last_keda_pause_annotation_if_present = "downscaler/original-pause-replicas"
 
     @property
     def replicas(self):
-        replicas = 0 if ScaledObject.keda_pause_annotation in self.annotations else 1
+        if ScaledObject.keda_pause_annotation in self.annotations:
+            if self.annotations[ScaledObject.keda_pause_annotation] == "0":
+                replicas = 0
+            elif self.annotations[ScaledObject.keda_pause_annotation] != "0":
+                replicas = int(self.annotations[ScaledObject.keda_pause_annotation])
+        else:
+            replicas = 1
+
         return replicas


### PR DESCRIPTION
WIth this PR I fixed a bug that prevented ScaledObjects from being paused if the "paused-replicas" annotation was already present inside the object

## Motivation

If, for some reason, the annotation `autoscaling.keda.sh/paused-replicas` is already present in the ScaledObject, the KubeDownscaler won't process the resource

This bug can happen if the developers incorrectly put this annotation at object creation.

For example this object:

```
apiVersion: keda.sh/v1alpha1
kind: ScaledObject
metadata:
  name: cron-scaledobject-2
  annotations:
    autoscaling.keda.sh/paused-replicas: "2"
spec:
  scaleTargetRef:
    name: hamster
  minReplicaCount: 2
  maxReplicaCount: 10
  triggers:
  - type: cron
    metadata:
      start: 0 0 * * *
      end: 0 6 * * *
      desiredReplicaCount: '10'
```

will be logged in this way inside the Kube-Downscaler

`2024-01-31 13:21:44,135 DEBUG: ScaledObject default/cron-scaledobject-2 has 0 replicas (original: None, uptime: Mon-Sun 07:30-10:45 CET)`

This is because the `keda.py `was defined as such 

```
class ScaledObject(NamespacedAPIObject):

    """Support the ScaledObject resource (https://keda.sh/docs/2.7/concepts/scaling-deployments/#scaledobject-spec)."""

    version = "keda.sh/v1alpha1"
    endpoint = "scaledobjects"
    kind = "ScaledObject"

    keda_pause_annotation = "autoscaling.keda.sh/paused-replicas"

    @property
    def replicas(self):
        replicas = 0 if ScaledObject.keda_pause_annotation in self.annotations else 1
        return replicas

```

the method "replicas" is called inside the "get_replicas" function of the `scaler.py `class and it always returns 0 with a ScaledObjects defined as the one above

## Changes

How the fix works: Each ScaledObjects will be scaled to 0 regardless of them having the annotation or not. However if the annotation `autoscaling.keda.sh/paused-replicas` was already present and with a value (like 2 or 3), during the next Cluster Uptime the ScaledObject will be restored at that configuration. The previous configuration "paused configuration" is saved inside a new annotation called `downscaler/original-pause-replicas`

## Tests done

Built the image and followed the workflow described above

## TODO

- [x] I've assigned myself to this PR
