### PR TITLE
fix: add necessary build tools & dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM python:3.10-alpine3.19
 
 WORKDIR /
 
+# Install necessary build tools and dependencies
+RUN apk add --no-cache gcc musl-dev libffi-dev python3-dev py3-setuptools
+
 RUN pip3 install poetry
 
 COPY poetry.lock /


### PR DESCRIPTION
## Motivation

This change addresses the build failure issue introduced in PR #39, where the transition to the `python:3.10-alpine3.19` base image resulted in missing build tools necessary for compiling certain Python packages. The failed pipeline can be viewed [here](https://github.com/caas-team/py-kube-downscaler/actions/runs/9170836607/job/25213872393). This update ensures that the necessary build dependencies are installed, allowing the pipeline to complete successfully. The successful pipeline build after the fix can be viewed [here](https://github.com/caas-team/py-kube-downscaler/actions/runs/9171869372/job/25217156668).

## Changes

- Added installation of build tools (`gcc`, `musl-dev`, `libffi-dev`, `python3-dev`, `py3-setuptools`) to the Dockerfile before installing `poetry`.

## Tests done

- Verified that the Docker image builds successfully without errors.
- Ensured the pipeline runs to completion, confirming the fix.

## TODO

- [x] I've assigned myself to this PR