### PR TITLE
feat: add prune workflow

### DIFF
--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -1,0 +1,39 @@
+name: Prune GHCR
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: write
+  packages: write
+  security-events: write
+
+jobs:
+  prune_images:
+    name: Prune old py-kube-downscaler images
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Prune Images
+        uses: vlaurin/action-ghcr-prune@v0.5.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          organization: ${{ github.repository_owner }}
+          container: py-kube-downscaler
+          keep-younger-than: 7 # days
+          prune-untagged: true
+          keep-tags-regexes: |
+            \bdev\b
+          prune-tags-regexes: |
+            ^commit-
+            ^sha256
+
+      - name: Prune Charts
+        uses: vlaurin/action-ghcr-prune@v0.5.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          organization: ${{ github.repository_owner }}
+          container: charts/py-kube-downscaler
+          keep-younger-than: 7 # days
+          prune-untagged: true


### PR DESCRIPTION
## Motivation
This pull request implements a new github workflow to prune any unnecessary images and charts to make it easier to manage.

It will prune all untagged images or images that start with commit or sha256 in the py-kube-downscaler package that are older than 7 days.

It will always keep the dev tag and shouldn't prune any of our releases.
<!--
Explain briefly what this change aims to achieve and why it is important to do so.
Please keep this description updated with any discussion that takes place so
that reviewers can understand your intent. Keeping the description updated is
especially important if they didn't participate in the discussion.
-->

## Changes
Added github workflow prune.yml.
<!--
List the changes made to the code base. Per default, all commits are listed here.
Please keep this description updated as you add new changes to the PR.
-->

## Tests done
I've tested the workflow in dry-run in a fork. 
https://github.com/JTaeuber/py-kube-downscaler/actions/runs/9188408222
<!--
List the tests that were done to verify the changes.
-->

## TODO

- [x] I've assigned myself to this PR
