### PR TITLE
Ensure configMapName Value is Used Consistently Across Templates

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "py-kube-downscaler.name" . }}
+  name: {{ .Values.configMapName }}
 data:
   # downscale for non-work hours
   EXCLUDE_NAMESPACES: '{{- join "," .Values.excludedNamespaces }}'


### PR DESCRIPTION
## Motivation

This change aims to address the issue where the `configMapName` key in the kube-downscaler Helm chart does not correctly set the name of the generated ConfigMap. 

- Solves: https://github.com/caas-team/py-kube-downscaler/issues/55

## Changes

- Updated `templates/configmap.yaml` to use the value of `configMapName` for the ConfigMap name.
- No changes to `templates/deployment.yaml`  - already using the value of `configMapName`.

## Tests done

- Rendered the Helm templates locally using `helm template` to verify that the `configMapName` value is correctly applied in the generated Kubernetes manifests.

## TODO

- [x] I've assigned myself to this PR