### PR TITLE
add tag expire workflow

### DIFF
--- a/.github/workflows/tag-expire.yaml
+++ b/.github/workflows/tag-expire.yaml
@@ -10,10 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     name: "expire-tags"
     steps:
-      - uses: eumel8/expire-action@1.0.0
+      - uses: eumel8/expire-action@1.0.1
         with:
           token: ${{secrets.TAGEXPIRE}}
           repo_type: org
           orgname: caas-team
           image_name: py-kube-downscaler
+          protected_tags: latest,24.5.2,24.5.0,24.4.0
           days_treshold: 60

--- a/.github/workflows/tag-expire.yaml
+++ b/.github/workflows/tag-expire.yaml
@@ -16,5 +16,5 @@ jobs:
           repo_type: org
           orgname: caas-team
           image_name: py-kube-downscaler
-          protected_tags: latest,24.5.2,24.5.0,24.4.0
+          protected_tags: sha256:c7df4b1295b2b60b43cbf9116b2c53883e26c8b935b0788564207413e8fa748f
           days_treshold: 60

--- a/.github/workflows/tag-expire.yaml
+++ b/.github/workflows/tag-expire.yaml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     name: "expire-tags"
     steps:
-      - uses: eumel8/expire-action@1.0.1
+      - uses: eumel8/expire-action@1.0.2
         with:
           token: ${{secrets.TAGEXPIRE}}
           repo_type: org
           orgname: caas-team
           image_name: py-kube-downscaler
-          protected_tags: sha256:c7df4b1295b2b60b43cbf9116b2c53883e26c8b935b0788564207413e8fa748f
+          protected_tags_regex: "^(latest|dev|[0-9][0-9]\\.\\d+\\.\\d+)$"
           days_treshold: 60

--- a/.github/workflows/tag-expire.yaml
+++ b/.github/workflows/tag-expire.yaml
@@ -1,0 +1,19 @@
+# https://github.com/marketplace/actions/expire-action
+on:
+  schedule:
+    - cron: "10 6 * * *"
+
+name: Expire container tags
+
+jobs:
+  expire-tags:
+    runs-on: ubuntu-latest
+    name: "expire-tags"
+    steps:
+      - uses: eumel8/expire-action@1.0.0
+        with:
+          token: ${{secrets.TAGEXPIRE}}
+          repo_type: org
+          orgname: caas-team
+          image_name: py-kube-downscaler
+          days_treshold: 60

--- a/.github/workflows/tag-expire.yaml
+++ b/.github/workflows/tag-expire.yaml
@@ -16,5 +16,5 @@ jobs:
           repo_type: org
           orgname: caas-team
           image_name: py-kube-downscaler
-          protected_tags_regex: "^(latest|dev|[0-9][0-9]\\.\\d+\\.\\d+)$"
+          protected_tags_regex: "^latest$\\|^dev$\\|^[0-9][0-9]\\\\.\\\\d+\\\\.\\\\d+$"
           days_treshold: 60


### PR DESCRIPTION
## Motivation

as discussed this week, more and more tags are stored in the package repository. At this time there is no auto-mechanism to expire older tags, so I developed this [action](https://github.com/marketplace/actions/expire-action)  to maintain the package repo and delete older tags then 60 days.

## Changes

- generate a PAT scoped package read/write
- added PAT to the repo
- added scheduled workflow 

## Tests done

manually tested on user/org package repo, works until the last tag is only present

## TODO

- [x] I've assigned myself to this PR
