### PR TITLE
fix: disable HPA downscaling by default

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -7,7 +7,7 @@ image:
 
 arguments:
   - --interval=60
-  - --include-resources=deployments,statefulsets,horizontalpodautoscalers,scaledobjects
+  - --include-resources=deployments,statefulsets,scaledobjects
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Motivation

The default downtime minimum replicas is 0; and the minReplicas field can't be 0 in HorizontalPodAutscaler.
Hence the default installation crashes when there are HorizontalPodAutoscalers with unspecified downscaler/downtime-replicas annotation.

## Changes

Disable the downscaling of HorizontalPodAutoscalers by default (it cannot work by default as it requires manual annotations to be functional).

## Tests done

1. deploy an HPA with no annotation
2. deploy py-kube-downscaler with default Helm variables
3. verify that py-kube-downscaler does not crash when downscaling happens