### PR TITLE
Fix/workflow cobertura report on pr

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -1,0 +1,38 @@
+name: Coverage Report
+
+on:
+  workflow_run:
+    workflows: ["Python Tests"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  issues: write
+  checks: write
+  pull-requests: write
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_commit.id }}
+      - name: Download Coverage Artifacts
+        uses: dawidd6/action-download-artifact@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          commit: ${{ github.event.workflow_run.head_commit.id }}
+          name: coverage
+          path: coverage
+      - name: Produce Coverage report
+        uses: 5monkeys/cobertura-action@master
+        with:
+          path: coverage/coverage.xml
+          minimum_coverage: 70
+          skip_covered: false

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -3,6 +3,7 @@ name: Python Tests
 on:
   push:
   pull_request:
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
@@ -13,21 +14,20 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.8
-    - name: Install dependencies
-      run: |
-        pip install poetry
-        poetry install
-    - name: Run pytest with coverage and generate report
-      run: poetry run pytest --cov=tests --cov-report=xml tests/
-    - name: Upload coverage to Cobertura
-      uses: 5monkeys/cobertura-action@master
-      with:
-        path: coverage.xml
-        minimum_coverage: 70
-        skip_covered: false
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          pip install poetry
+          poetry install
+      - name: Run pytest with coverage and generate report
+        run: poetry run pytest --cov=tests --cov-report=xml tests/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.xml


### PR DESCRIPTION
## Motivation

This change aims to address the issue where GitHub Actions workflows fail due to insufficient permissions when running on pull requests from forks. By splitting the workflow into two separate workflows, we can circumvent the permissions issue and ensure coverage reports are generated correctly.

- Solves: https://github.com/caas-team/py-kube-downscaler/issues/59

## Changes

- Adjusted `python-tests.yml` to handle running tests and uploading coverage artifacts.
- Created `coverage-report.yml` to generate coverage reports based on artifacts from the first workflow.

## Tests done

None

## TODO

- [x] I've assigned myself to this PR
