### PR TITLE
Facilitates backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Scale down / "pause" Kubernetes workload (`Deployments`, `StatefulSets`,
     - [Scaling Daemonsets](#scaling-daemonset)
     - [Matching Labels Argument](#matching-labels-argument)
     - [Namespace Defaults](#namespace-defaults)
+  - [Migrate From Codeberg](#migrate-from-codeberg)
   - [Contributing](#contributing)
   - [License](#license)
 
@@ -508,6 +509,22 @@ The following annotations are supported on the Namespace level:
 -   `downscaler/downtime-replicas`: overwrite the default target
     replicas to scale down to (default: zero)
 
+## Migrate From Codeberg
+
+For all users who come from the Codeberg repository (no longer maintained by the original author) 
+it is possible to migrate to this new version of the kube-downscaler by installing the Helm chart in this way:
+
+```bash
+$ helm install kube-downscaler py-kube-downscaler/py-kube-downscaler --set nameOverride=kube-downscaler --set configMapName=kube-downscaler
+```
+
+or extracting and applying the template manually:
+
+```bash
+$ helm template kube-downscaler py-kube-downscaler/py-kube-downscaler --set nameOverride=kube-downscaler --set configMapName=kube-downscaler
+```
+
+Installing the chart in this way will preserve the old nomenclature already present in your cluster
 
 ## Contributing
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -70,6 +70,7 @@ configMapName: py-kube-downscaler
 # DEFAULT_UPTIME: "Mon-Fri 07:30-20:30 CET"
 excludedNamespaces:
   - py-kube-downscaler
+  - kube-downscaler
   - kube-system
 
 # Additional config in the configmap.

--- a/kube_downscaler/cmd.py
+++ b/kube_downscaler/cmd.py
@@ -84,8 +84,8 @@ def get_parser():
     )
     parser.add_argument(
         "--exclude-deployments",
-        help="Exclude specific deployments from downscaling. Despite its name, this option will match the name of any included resource type (Deployment, StatefulSet, CronJob, ..). (default: py-kube-downscaler,downscaler)",
-        default=os.getenv("EXCLUDE_DEPLOYMENTS", "py-kube-downscaler,downscaler"),
+        help="Exclude specific deployments from downscaling. Despite its name, this option will match the name of any included resource type (Deployment, StatefulSet, CronJob, ..). (default: py-kube-downscaler,kube-downscaler,downscaler)",
+        default=os.getenv("EXCLUDE_DEPLOYMENTS", "py-kube-downscaler,kube-downscaler,downscaler"),
     )
     parser.add_argument(
         "--downtime-replicas",


### PR DESCRIPTION
## Motivation

This small change helps migrate from the version of the Kubedownscaler published on Codeberg to the new version maintained here on Github.

The old namespace name "kube-downscaler" is added among the default values ​​inside the chart helm "Excluded Namespace" section and inside the cmd.py class.

Refactored docs to explain how to migrate from the old Codeberg repo

## Changes

`cmd.py`
`values.yaml `
`readme`

as described in the section above 

## Tests done

Unit tests

## TODO

- [x] I've assigned myself to this PR
