### PR TITLE
New Feature: New Downscaler/Grace-Period Annotation To Override Global Grace Period for Individual Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,10 @@ Available command line options:
 :   Grace period in seconds for new deployments before scaling them down
     (default: 15min). The grace period counts from time of creation of
     the deployment, i.e. updated deployments will immediately be scaled
-    down regardless of the grace period.
+    down regardless of the grace period. If the `downscaler/grace-period` 
+    annotation is present in a resource and its value is shorter than 
+    the global grace period, the annotation's value will override the
+    global grace period for that specific resource.
 
 `--upscale-period`
 
@@ -448,6 +451,9 @@ to exclude jobs. As described above, despite their names, these variables work f
 annotations are not supported if specified directly inside the Job definition due to limitations 
 on computing days of the week inside the policies. However you can still use 
 these annotations at Namespace level to downscale/upscale Jobs 
+
+`downscaler/downscale-period` annotation is only supported at namespace level when used
+to scale down jobs with Admission Controllers
 
 **Deleting Policies:** if for some reason you want to delete all resources blocking jobs, you can use these commands:
 

--- a/README.md
+++ b/README.md
@@ -452,8 +452,11 @@ annotations are not supported if specified directly inside the Job definition du
 on computing days of the week inside the policies. However you can still use 
 these annotations at Namespace level to downscale/upscale Jobs 
 
-`downscaler/downscale-period` annotation is only supported at namespace level when used
-to scale down jobs with Admission Controllers
+**<u>Important</u>:** 
+global `--grace-period` is not supported for this feature at the moment, however `downscaler/downscale-period` annotation is 
+supported at namespace level when used to scale down jobs with Admission Controllers
+
+**<u>Important</u>:** 
 
 **Deleting Policies:** if for some reason you want to delete all resources blocking jobs, you can use these commands:
 

--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -100,13 +100,25 @@ def within_grace_period(
 
     if grace_period_annotation is not None and is_grace_period_annotation_integer(grace_period_annotation):
         grace_period_annotation_integer = int(grace_period_annotation)
-        if grace_period_annotation_integer <= grace_period and grace_period_annotation_integer > 0:
-            logger.info(
-                f"Grace period annotation found for {resource.kind} {resource.name} in namespace {resource.namespace}. "
-                f"Since the grace period specified in the annotation is shorter than the global grace period, "
-                f"the downscaler will use the annotation's grace period for this resource."
+
+        if grace_period_annotation_integer > 0:
+            if grace_period_annotation_integer <= grace_period:
+                logger.info(
+                    f"Grace period annotation found for {resource.kind} {resource.name} in namespace {resource.namespace}. "
+                    f"Since the grace period specified in the annotation is shorter than the global grace period, "
+                    f"the downscaler will use the annotation's grace period for this resource."
+                )
+                grace_period = grace_period_annotation_integer
+            else:
+                logger.info(
+                    f"Grace period annotation found for {resource.kind} {resource.name} in namespace {resource.namespace}. "
+                    f"The global grace period is shorter, so the downscaler will use the global grace period for this resource."
+                )
+        else:
+            logger.warning(
+                f"Grace period annotation found for {resource.kind} {resource.name} in namespace {resource.namespace} "
+                f"but cannot be a negative integer"
             )
-            grace_period = grace_period_annotation_integer
 
     if deployment_time_annotation:
         annotations = resource.metadata.get("annotations", {})

--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -103,19 +103,19 @@ def within_grace_period(
 
         if grace_period_annotation_integer > 0:
             if grace_period_annotation_integer <= grace_period:
-                logger.info(
+                logger.debug(
                     f"Grace period annotation found for {resource.kind} {resource.name} in namespace {resource.namespace}. "
                     f"Since the grace period specified in the annotation is shorter than the global grace period, "
                     f"the downscaler will use the annotation's grace period for this resource."
                 )
                 grace_period = grace_period_annotation_integer
             else:
-                logger.info(
+                logger.debug(
                     f"Grace period annotation found for {resource.kind} {resource.name} in namespace {resource.namespace}. "
                     f"The global grace period is shorter, so the downscaler will use the global grace period for this resource."
                 )
         else:
-            logger.warning(
+            logger.debug(
                 f"Grace period annotation found for {resource.kind} {resource.name} in namespace {resource.namespace} "
                 f"but cannot be a negative integer"
             )
@@ -145,13 +145,25 @@ def within_grace_period_namespace(
 
     if grace_period_annotation is not None and is_grace_period_annotation_integer(grace_period_annotation):
         grace_period_annotation_integer = int(grace_period_annotation)
-        if grace_period_annotation_integer <= grace_period:
-            logger.info(
-                f"Grace period annotation found for {resource.name} namespace. "
-                f"Since the grace period specified in the annotation is shorter than the global grace period, "
-                f"the downscaler will use the annotation's grace period for this namespace."
+
+        if grace_period_annotation_integer > 0:
+            if grace_period_annotation_integer <= grace_period:
+                logger.debug(
+                    f"Grace period annotation found for namespace {resource.name}. "
+                    f"Since the grace period specified in the annotation is shorter than the global grace period, "
+                    f"the downscaler will use the annotation's grace period for this resource."
+                )
+                grace_period = grace_period_annotation_integer
+            else:
+                logger.debug(
+                    f"Grace period annotation found for namespace {resource.name}. "
+                    f"The global grace period is shorter, so the downscaler will use the global grace period for this resource."
+                )
+        else:
+            logger.debug(
+                f"Grace period annotation found for namespace {resource.name} "
+                f"but cannot be a negative integer"
             )
-            grace_period = grace_period_annotation_integer
 
     if deployment_time_annotation:
         annotations = resource.metadata.get("annotations", {})

--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -38,6 +38,7 @@ EXCLUDE_UNTIL_ANNOTATION = "downscaler/exclude-until"
 UPTIME_ANNOTATION = "downscaler/uptime"
 DOWNTIME_ANNOTATION = "downscaler/downtime"
 DOWNTIME_REPLICAS_ANNOTATION = "downscaler/downtime-replicas"
+GRACE_PERIOD_ANNOTATION="downscaler/grace-period"
 
 RESOURCE_CLASSES = [
     Deployment,
@@ -79,6 +80,13 @@ def parse_time(timestamp: str) -> datetime.datetime:
         f"time data '{timestamp}' does not match any format ({', '.join(TIMESTAMP_FORMATS)})"
     )
 
+def is_grace_period_annotation_integer(value):
+    try:
+        int(value)  # Attempt to convert the string to an integer
+        return True
+    except ValueError:
+        return False
+
 
 def within_grace_period(
     resource,
@@ -87,6 +95,18 @@ def within_grace_period(
     deployment_time_annotation: Optional[str] = None,
 ):
     update_time = parse_time(resource.metadata["creationTimestamp"])
+
+    grace_period_annotation = resource.annotations.get(GRACE_PERIOD_ANNOTATION, None)
+
+    if grace_period_annotation is not None and is_grace_period_annotation_integer(grace_period_annotation):
+        grace_period_annotation_integer = int(grace_period_annotation)
+        if grace_period_annotation_integer <= grace_period and grace_period_annotation_integer > 0:
+            logger.info(
+                f"Grace period annotation found for {resource.kind} {resource.name} in namespace {resource.namespace}. "
+                f"Since the grace period specified in the annotation is shorter than the global grace period, "
+                f"the downscaler will use the annotation's grace period for this resource."
+            )
+            grace_period = grace_period_annotation_integer
 
     if deployment_time_annotation:
         annotations = resource.metadata.get("annotations", {})
@@ -108,6 +128,18 @@ def within_grace_period_namespace(
         deployment_time_annotation: Optional[str] = None,
 ):
     update_time = parse_time(resource.metadata["creationTimestamp"])
+
+    grace_period_annotation = resource.annotations.get(GRACE_PERIOD_ANNOTATION, None)
+
+    if grace_period_annotation is not None and is_grace_period_annotation_integer(grace_period_annotation):
+        grace_period_annotation_integer = int(grace_period_annotation)
+        if grace_period_annotation_integer <= grace_period:
+            logger.info(
+                f"Grace period annotation found for {resource.name} namespace. "
+                f"Since the grace period specified in the annotation is shorter than the global grace period, "
+                f"the downscaler will use the annotation's grace period for this namespace."
+            )
+            grace_period = grace_period_annotation_integer
 
     if deployment_time_annotation:
         annotations = resource.metadata.get("annotations", {})

--- a/tests/test_grace_period.py
+++ b/tests/test_grace_period.py
@@ -7,6 +7,7 @@ from pykube import Deployment
 from kube_downscaler.scaler import within_grace_period
 
 ANNOTATION_NAME = "my-deployment-time"
+GRACE_PERIOD_ANNOTATION="downscaler/grace-period"
 
 
 def test_within_grace_period_creation_time():
@@ -18,6 +19,47 @@ def test_within_grace_period_creation_time():
     assert within_grace_period(deploy, 900, now)
     assert not within_grace_period(deploy, 180, now)
 
+def test_within_grace_period_override_annotation():
+    now = datetime.now(timezone.utc)
+    ts = now - timedelta(minutes=2)
+    deploy = Deployment(
+        None,
+        {
+            "metadata":
+             {
+                 "name": "grace-period-test-deployment",
+                 "namespace": "test-namespace",
+                 "creationTimestamp": ts.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                 "annotations": {
+                     GRACE_PERIOD_ANNOTATION: "300"
+                 }
+             }
+         }
+    )
+
+    assert within_grace_period(deploy, 900, now)
+    assert not within_grace_period(deploy, 119, now)
+    assert within_grace_period(deploy, 123, now)
+
+def test_within_grace_period_override_wrong_annotation_value():
+    now = datetime.now(timezone.utc)
+    ts = now - timedelta(minutes=5)
+    deploy = Deployment(
+        None,
+        {
+            "metadata":
+             {
+                 "name": "grace-period-test-deployment",
+                 "namespace": "test-namespace",
+                 "creationTimestamp": ts.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                 "annotations": {
+                     GRACE_PERIOD_ANNOTATION: "wrong"
+                 }
+             }
+         }
+    )
+    assert within_grace_period(deploy, 900, now)
+    assert not within_grace_period(deploy, 180, now)
 
 def test_within_grace_period_deployment_time_annotation():
     now = datetime.now(timezone.utc)


### PR DESCRIPTION
## Motivation

This feature introduces the ability to override the global grace period defined by the `--grace-period` argument in the main deployment. By using the new `downscaler/grace-period` annotation, you can set a specific grace period for individual resources.

**Important**: The annotation will only override the global grace period if the value specified in the annotation is shorter than the globally defined grace period. This ensures that the feature cannot be misused by users to extend the grace period beyond the intended limit.

## Changes

- a new annotation was introduced: `downscaler/grace-period`
- `within_grace_period` and `within_grace_period_namespace` functions where refactored to implement the logic described above

## Tests done

Unit tests inside `test_grace_period.py`

## TODO

- [x] I've assigned myself to this PR
