### PR TITLE
Fix KEDA ScaledObject KeyError on upscaling

### DIFF
--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -589,8 +589,8 @@ def scale_up(
             f"Scaling up {resource.kind} {resource.namespace}/{resource.name} from {replicas} to {original_replicas} replicas (uptime: {uptime}, downtime: {downtime})"
         )
     elif resource.kind == "ScaledObject":
-        if ScaledObject.keda_pause_annotation in resource.annotations:
-            if resource.annotations[ScaledObject.keda_pause_annotation] is not None:
+        if ScaledObject.last_keda_pause_annotation_if_present in resource.annotations:
+            if resource.annotations[ScaledObject.last_keda_pause_annotation_if_present] is not None:
                 paused_replicas = resource.annotations[ScaledObject.last_keda_pause_annotation_if_present]
                 resource.annotations[ScaledObject.keda_pause_annotation] = paused_replicas
                 resource.annotations[ScaledObject.last_keda_pause_annotation_if_present] = None


### PR DESCRIPTION
## Motivation

The ScaledObject fix https://github.com/caas-team/py-kube-downscaler/pull/87 introduced yesterday handles the downscaling properly.

However this commit https://github.com/caas-team/py-kube-downscaler/commit/71c465f61f520c6528203164740b08d9026c17d0 breaks upscaling of ScaledObject when there was no `autoscaling.keda.sh/paused-replicas` annotation set before and therefore annotation `downscaler/original-pause-replicas` is missing.

```
2024-08-23 08:11:35,472 ERROR: Failed to process ScaledObject wp-bedrock-sample/wp-bedrock-sample-wordpress-bedrock: 'downscaler/original-pause-replicas'
Traceback (most recent call last):                                                                                                                             
  File "/kube_downscaler/scaler.py", line 934, in autoscale_resource                                                                                           
    scale_up(                                                                                                                                                  
  File "/kube_downscaler/scaler.py", line 594, in scale_up                                                                                                     
    paused_replicas = resource.annotations[ScaledObject.last_keda_pause_annotation_if_present]                                                                 
KeyError: 'downscaler/original-pause-replicas'  
```

## Changes

Upscale event for ScaledObject checks for existance of annotation `downscaler/original-pause-replicas` prior to restore `autoscaling.keda.sh/paused-replicas`.

## Tests done

None so far

## TODO

- [x] I've assigned myself to this PR
