### PR TITLE
Enhanced Tests For Scaled Objects Downscaling/Upscaling

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,5 +3,5 @@ name: py-kube-downscaler
 description: A Helm chart for deploying py-kube-downscaler
 
 type: application
-version: 0.2.6
-appVersion: "24.8.1"
+version: 0.2.7
+appVersion: "24.8.2"

--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -63,6 +63,7 @@ rules:
     - batch
   resources:
     - cronjobs
+    - jobs
   verbs:
     - get
     - watch

--- a/kube_downscaler/resources/keda.py
+++ b/kube_downscaler/resources/keda.py
@@ -15,9 +15,11 @@ class ScaledObject(NamespacedAPIObject):
     @property
     def replicas(self):
         if ScaledObject.keda_pause_annotation in self.annotations:
-            if self.annotations[ScaledObject.keda_pause_annotation] == "0":
+            if self.annotations[ScaledObject.keda_pause_annotation] is None:
+                replicas = 1
+            elif self.annotations[ScaledObject.keda_pause_annotation] == "0":
                 replicas = 0
-            elif self.annotations[ScaledObject.keda_pause_annotation] != "0":
+            elif self.annotations[ScaledObject.keda_pause_annotation] != "0" and self.annotations[ScaledObject.keda_pause_annotation] is not None:
                 replicas = int(self.annotations[ScaledObject.keda_pause_annotation])
         else:
             replicas = 1

--- a/tests/test_autoscale_resource.py
+++ b/tests/test_autoscale_resource.py
@@ -1238,8 +1238,8 @@ def test_downscale_scaledobject_without_keda_pause_annotation():
                 "name": "scaledobject-1",
                 "namespace": "default",
                 "creationTimestamp": "2023-08-21T10:00:00Z",
+                "annotations": {}
             },
-            "spec": {"replicas": 3},
         }
     )
 
@@ -1263,8 +1263,8 @@ def test_downscale_scaledobject_without_keda_pause_annotation():
 
     # Check if the annotations have been correctly updated
     assert so.annotations[ScaledObject.keda_pause_annotation] == "0"
-    assert so.replicas == 0
     assert so.annotations.get(ScaledObject.last_keda_pause_annotation_if_present) is None
+    assert so.replicas == 0
 
 
 def test_upscale_scaledobject_without_keda_pause_annotation():
@@ -1277,11 +1277,9 @@ def test_upscale_scaledobject_without_keda_pause_annotation():
                 "creationTimestamp": "2023-08-21T10:00:00Z",
                 "annotations": {
                     "autoscaling.keda.sh/paused-replicas": "0",
-                    "downscaler/original-pause-replicas": "3",
                     "downscaler/original-replicas": "3",
                 }
             },
-            "spec": {"replicas": 0},
         }
     )
 
@@ -1304,6 +1302,6 @@ def test_upscale_scaledobject_without_keda_pause_annotation():
     )
 
     # Check if the annotations have been correctly updated for the upscale operation
-    assert so.annotations[ScaledObject.keda_pause_annotation] == "3"
-    assert so.replicas == 3
+    assert so.annotations[ScaledObject.keda_pause_annotation] is None
     assert so.annotations.get(ScaledObject.last_keda_pause_annotation_if_present) is None
+    assert so.replicas == 1


### PR DESCRIPTION
## Motivation

1. Enhanced Tests For Scaled Objects Downscaling/Upscaling. 
2. Added inside keda.py a logic to handle "autoscaling.keda.sh/paused-replicas" is None 

The second behavior described above only happens inside test classes, this is for a reason:
- In real life Kubernetes will delete the annotation when it is set to None 
- In Python it will be assigned the real None type

## Changes

Enhanced Tests For Scaled Objects Downscaling/Upscaling

## Tests done

Unit Tests

## TODO

- [x] I've assigned myself to this PR
