### PR TITLE
Added missing job resource on clusterrole

### DIFF
--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -177,6 +177,7 @@ rules:
     - batch
   resources:
     - cronjobs
+    - jobs
   verbs:
     - get
     - watch


### PR DESCRIPTION
## Motivation

This update fixes 403 that error that occurs if you deploy KD with the helm chart and include job resources. 
This error occurred because the service account did not had permission to manage **job** resources.

## Changes

On ClusterRole at the helm template **rbac.yaml** added the **jobs** resource next to **cronjobs**.

## Tests done

None