### PR TITLE
Chore/bump to24.10.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
     rev: 0.2.0
     hooks:
       - id: kube-manifest-lint
-        exclude: ^unsupported/helm-chart/templates/.*$|kustomization.yaml
 
   # formatters
   - repo: https://github.com/asottile/reorder_python_imports
@@ -46,7 +45,6 @@ repos:
 
   - repo: local
     hooks:
-
       - id: safety
         name: safety
         entry: safety
@@ -71,10 +69,10 @@ repos:
         args: ["--strict", "-d", "{rules: {line-length: {max: 180}}}"]
         #
         exclude: >
-            (?x)^(
-                ^{{.*}}.*\.yaml$|
-                ^unsupported/helm-chart/templates/.*$
-            )
+          (?x)^(
+              ^{{.*}}.*\.yaml$|
+              ^unsupported/helm-chart/templates/.*$
+          )
         #
 
   - repo: https://github.com/pre-commit/mirrors-mypy
@@ -87,7 +85,7 @@ repos:
     rev: v0.1.0
     hooks:
       - id: dockerfilelint
-        stages: [commit]  # required
+        stages: [commit] # required
 
   # miscellaneous
   - repo: https://gitlab.com/pycqa/flake8
@@ -124,6 +122,6 @@ repos:
   # http://jorisroovers.com/gitlint/#using-gitlint-through-pre-commit
 
   - repo: https://github.com/jorisroovers/gitlint
-    rev:  v0.17.0
+    rev: v0.17.0
     hooks:
       - id: gitlint

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="/../../issues/" title="GitHub Issues"><img alt="GitHub Issues" src="https://img.shields.io/github/issues/caas-team/py-kube-downscaler"></a>
 <a href="https://communityinviter.com/apps/kube-downscaler/kube-downscaler" title="Slack Workspace"><img alt="Slack Workspace" src="https://img.shields.io/badge/slack-kube--downscaler-dark_green?style=flat&logo=slack"></a>
 
-This is a fork of [hjacobs/kube-downscaler](https://codeberg.org/hjacobs/kube-downscaler) which is no longer maintained.
+This is a fork of the no longer maintained [hjacobs/kube-downscaler](https://codeberg.org/hjacobs/kube-downscaler).
 
 Scale down / "pause" Kubernetes workload (`Deployments`, `StatefulSets`,
 `HorizontalPodAutoscalers`, `DaemonSets`, `CronJobs`, `Jobs`, `PodDisruptionBudgets`, `Argo Rollouts` and `Keda ScaledObjects` too !) during non-work hours.
@@ -36,10 +36,12 @@ Scale down / "pause" Kubernetes workload (`Deployments`, `StatefulSets`,
     - [Scaling Jobs: Overview](#scaling-jobs-overview)
     - [Scaling Jobs Natively](#scaling-jobs-natively)
     - [Scaling Jobs With Admission Controller](#scaling-jobs-with-admission-controller)
-    - [Scaling Daemonsets](#scaling-daemonset)
+    - [Scaling DaemonSets](#scaling-daemonsets)
     - [Matching Labels Argument](#matching-labels-argument)
     - [Namespace Defaults](#namespace-defaults)
   - [Migrate From Codeberg](#migrate-from-codeberg)
+    - [Migrate From Codeberg - Cluster Wide Installation](#migrate-from-codeberg---cluster-wide-installation)
+    - [Migrate From Codeberg - Limited Access Installation](#migrate-from-codeberg---limited-access-installation)
   - [Contributing](#contributing)
   - [License](#license)
 
@@ -585,7 +587,7 @@ Kyverno
 $ kubectl delete policies -A -l origin=kube-downscaler
 ```
 
-### Scaling DaemonSet
+### Scaling DaemonSets
 
 The feature to scale DaemonSets can be very useful for reducing the base occupancy of a node. If enabled, the DaemonSets downscaling algorithm works like this:
 
@@ -715,9 +717,8 @@ $ helm template kube-downscaler py-kube-downscaler/py-kube-downscaler --set name
 
 ## Contributing
 
-Easiest way to contribute is to provide feedback! We would love to hear
-what you like and what you think is missing. Create an issue or [ping
-try_except\_ on Twitter](https://twitter.com/try_except_).
+Easiest way to contribute is to provide feedback! We would love to hear what you like and what you think is missing.
+Create an issue and we will take a look. PRs are welcome.
 
 PRs are welcome.
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,5 +3,5 @@ name: py-kube-downscaler
 description: A Helm chart for deploying py-kube-downscaler
 
 type: application
-version: 0.2.8
-appVersion: "24.8.3"
+version: 0.2.9
+appVersion: "24.10.0"


### PR DESCRIPTION
## Motivation
This pull request aims to bump the version numbers to make a new release in order to fix https://github.com/caas-team/py-kube-downscaler/issues/97.
<!--
Explain briefly what this change aims to achieve and why it is important to do so.
Please keep this description updated with any discussion that takes place so
that reviewers can understand your intent. Keeping the description updated is
especially important if they didn't participate in the discussion.
-->

## Changes
* Bumped appVersion and version numbers.
* Made a few changes to the README.md that were overdue
* Removed outdated exclusion path from pre-commit-config.yaml
<!--
List the changes made to the code base. Per default, all commits are listed here.
Please keep this description updated as you add new changes to the PR.
-->



<!--
List the tests that were done to verify the changes.
-->

## TODO
There might still be some things that are not quite up to date. I will take a look when i have the time. For the meantime this doesn't pose as a big problem.

- [x] I've assigned myself to this PR
