### PR TITLE
fix(chart value): fixing interval from 60 to 30 as it's the default

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -6,7 +6,7 @@ image:
   tag: ""  # Dynamically set from CI
 
 arguments:
-  - --interval=60
+  - --interval=30
   - --include-resources=deployments,statefulsets,scaledobjects
 
 imagePullSecrets: []


### PR DESCRIPTION
## Motivation
From docs, default interval values is 30 but on chart values 60 is set.

