### PR TITLE
Chore: Update Python Version to 3.12.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-alpine3.19
+FROM python:3.12.7-alpine3.20 AS builder
 
 WORKDIR /
 
@@ -13,12 +13,12 @@ COPY pyproject.toml /
 RUN poetry config virtualenvs.create false && \
     poetry install --no-interaction --no-dev --no-ansi
 
-FROM python:3.10-alpine3.19
+FROM python:3.12.7-alpine3.20
 
 WORKDIR /
 
 # copy pre-built packages to this image
-COPY --from=0 /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
+COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
 
 # now copy the actual code we will execute (poetry install above was just for dependencies)
 COPY kube_downscaler /kube_downscaler


### PR DESCRIPTION
## Motivation

As stated in issue #114 due to the Python version the project is using right now, the Docker image suffers from the following vulnerabilities:

- https://github.com/advisories/GHSA-cx63-2mw6-8hw5 Severity High - setuptools
- https://github.com/advisories/GHSA-mq26-g339-26xf Severity Medium - pip

## Changes

- Built a new image with Python 3.12.7

## Tests done

- Built the new image and tested inside a test cluster
- Unit Tests

## TODO

- [x] I've assigned myself to this PR
