### PR TITLE
Fix: Api Server Timeout Argument Doesn't Override Default Timeout Value

### DIFF
--- a/kube_downscaler/helper.py
+++ b/kube_downscaler/helper.py
@@ -65,9 +65,9 @@ def _matches_absolute_time_spec(time: datetime.datetime, match: Match):
     return time_from <= time <= time_to
 
 
-def get_kube_api():
+def get_kube_api(timeout: int):
     config = pykube.KubeConfig.from_env()
-    api = pykube.HTTPClient(config)
+    api = pykube.HTTPClient(config, timeout=timeout)
     return api
 
 

--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -1142,8 +1142,7 @@ def apply_kubedownscalerjobsconstraint_crd(excluded_names, matching_labels, api)
         time.sleep(0.02)
 
 
-def gatekeeper_constraint_template_crd_exist() -> bool:
-    api = helper.get_kube_api()
+def gatekeeper_constraint_template_crd_exist(api) -> bool:
     constraint_template_crd = CustomResourceDefinition.objects(api).get_or_none(
         name="constrainttemplates.templates.gatekeeper.sh")
 
@@ -1227,7 +1226,7 @@ def autoscale_jobs(
 ):
     if admission_controller != "" and admission_controller in ADMISSION_CONTROLLERS:
 
-        if admission_controller == "gatekeeper" and gatekeeper_constraint_template_crd_exist():
+        if admission_controller == "gatekeeper" and gatekeeper_constraint_template_crd_exist(api):
             apply_kubedownscalerjobsconstraint_crd(exclude_names, matching_labels, api)
             if admission_controller == "gatekeeper" and not gatekeeper_healthy(api):
                 logging.error("unable to scale jobs, there was a problem applying kubedownscalerjobsconstraint crd or it was deleted"

--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -1357,11 +1357,10 @@ def scale(
     enable_events: bool = False,
     matching_labels: FrozenSet[Pattern] = frozenset(),
 ):
-    api = helper.get_kube_api()
+    api = helper.get_kube_api(api_server_timeout)
 
     now = datetime.datetime.now(datetime.timezone.utc)
     forced_uptime = pods_force_uptime(api, namespaces)
-    pykube.http.DEFAULT_HTTP_TIMEOUT=api_server_timeout
 
     for clazz in RESOURCE_CLASSES:
         plural = clazz.endpoint

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -12,6 +12,41 @@ from kube_downscaler.scaler import autoscale_jobs
 from kube_downscaler.scaler import scale_down_jobs
 from kube_downscaler.scaler import scale_up_jobs
 
+def test_scale_custom_timeout(monkeypatch):
+    api_server_timeout = 15  # Defined by the user
+    api = MagicMock()
+    api.timeout = 15  # Expected timeout
+
+    mock_get_kube_api = MagicMock(return_value=api)
+    monkeypatch.setattr(
+        "kube_downscaler.scaler.helper.get_kube_api", mock_get_kube_api
+    )
+
+    scale(
+        namespaces=frozenset({"default"}),
+        upscale_period="never",
+        downscale_period="never",
+        default_uptime="never",
+        default_downtime="always",
+        upscale_target_only=False,
+        include_resources=frozenset(["pods"]),
+        exclude_namespaces=frozenset(),
+        exclude_deployments=frozenset(),
+        dry_run=False,
+        grace_period=300,
+        admission_controller="",
+        constrained_downscaler=False,
+        api_server_timeout=api_server_timeout,
+        downtime_replicas=0,
+        deployment_time_annotation=None,
+        enable_events=False,
+        matching_labels=frozenset(),
+    )
+
+    # ensure get_kube_api is called with the correct timeout value
+    mock_get_kube_api.assert_called_once_with(api_server_timeout)
+    # ensure timeout value is correctly set on the returned object
+    assert api.timeout == api_server_timeout
 
 def test_scaler_always_up(monkeypatch):
     api = MagicMock()


### PR DESCRIPTION
## Motivation

The newly introduced `--api-server-timeout` is not applying the user-defined timeout to the Kubeconfig created by Pykube because the monkey patching occurs after the Kubeconfig has been created.

## Changes

Refactored the logic, the `--api-server-timeout` will inject its value thourgh the HTTPObject Constructor instead of monkeypatching PyKube library

## Tests done

- Unit Tests
- Built a Custom Imaged and Tested

## TODO

- [x] I've assigned myself to this PR
