### PR TITLE
Fix: Added imagePullSecret customization support

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -35,6 +35,10 @@ spec:
           {{- toYaml .Values.resources | nindent 10 }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
     {{- with .Values.nodeSelector }}


### PR DESCRIPTION
## Motivation

ImagePullSecret is referred to as customizable in the chart's values.yaml , yet it is not managed in the deployment template.
We need this fix since we use a privately hosted registry with private repos in our organization.

## Changes

ImagePullSecret added to the deployment template.

## Tests done

- Unit Tests

## TODO

- [x] Assign someone to the PR
