### PR TITLE
Fix: Test_Scale_Custom_Timeout After Merging

### DIFF
--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -37,6 +37,7 @@ def test_scale_custom_timeout(monkeypatch):
         admission_controller="",
         constrained_downscaler=False,
         api_server_timeout=api_server_timeout,
+        max_retries_on_conflict=0,
         downtime_replicas=0,
         deployment_time_annotation=None,
         enable_events=False,


### PR DESCRIPTION
## Motivation

After merging the `test_scale_custom_timeout` was missing the `max_retries_on_conflict` argument

## Changes

inserting `max_retries_on_conflict` argument inside the test

## Tests done

Unit tests

## TODO

- [x] I've assigned myself to this PR
