### PR TITLE
Chore: Adjust Python Version

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install dependencies
         run: |
           pip install poetry


### PR DESCRIPTION
## Motivation

Since we bumped the minimum required Python version to [3.9 in pyproject.toml](https://github.com/caas-team/py-kube-downscaler/pull/112/commits/9472cdac13a5d80c453bfb37cbcf92dd53159671), we should align our Python test workflow to use the same version.

## Changes

- Updated the Python version in the GitHub Actions workflow for tests from `3.8` to `3.9`.

## Tests Done

- Verified that the GitHub Actions workflow runs successfully with the updated Python version.

## TODO

- [x] Assign myself to this PR.
