### PR TITLE
add pod restart on config changes

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,5 +3,5 @@ name: py-kube-downscaler
 description: A Helm chart for deploying py-kube-downscaler
 
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "25.3.0"

--- a/chart/README.md
+++ b/chart/README.md
@@ -4,12 +4,13 @@ This repository offers a Helm chart for the `py-kube-downscaler`.
 
 ## Important values
 
-| Key                | Type   | Example                                                                                               | Description                                     |
-| ------------------ | ------ | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| image.tag          | string | `"23.2.0@sha256:4129e7e7551eb451ee2b43680ef818f3057304ad50888f79ec9722afab6c29ff"`                    | Tag of the image to use                         |
-| arguments          | list   | `[--interval=60,--include-resources=deployments,statefulsets,horizontalpodautoscalers,scaledobjects]` | Arguments to pass to the kube-downscaler binary |
-| excludedNamespaces | list   | `["namespace-a", "namespace-b"]`                                                                      | Namespaces to exclude from downscaling          |
-| extraConfig        | string | `"DOWNSCALE_PERIOD: 'Mon-Sun 19:00-20:00 Europe/Berlin'"`                                             | Additional configuration in ConfigMap format    |
+| Key                        | Type   | Example                                                                                               | Description                                      |
+| -------------------------- | ------ | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| image.tag                  | string | `"23.2.0@sha256:4129e7e7551eb451ee2b43680ef818f3057304ad50888f79ec9722afab6c29ff"`                    | Tag of the image to use                          |
+| arguments                  | list   | `[--interval=60,--include-resources=deployments,statefulsets,horizontalpodautoscalers,scaledobjects]` | Arguments to pass to the kube-downscaler binary  |
+| excludedNamespaces         | list   | `["namespace-a", "namespace-b"]`                                                                      | Namespaces to exclude from downscaling           |
+| extraConfig                | string | `"DOWNSCALE_PERIOD: 'Mon-Sun 19:00-20:00 Europe/Berlin'"`                                             | Additional configuration in ConfigMap format     |
+| forceRestartOnConfigChange | bool   | `false`                                                                                               | Force pod restart when the configuration changes |
 
 # Deploy py-kube-downscaler using Helm chart
 

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -13,10 +13,15 @@ spec:
     metadata:
       labels:
         {{- include "py-kube-downscaler.selectorLabels" . | nindent 8 }}
-    {{- with .Values.podAnnotations }}
+      {{- if or .Values.podAnnotations .Values.forceRestartOnConfigChange }}
       annotations:
+        {{- if .Values.forceRestartOnConfigChange }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+        {{- end }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "py-kube-downscaler.serviceAccountName" . }}
       containers:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -72,3 +72,6 @@ excludedNamespaces:
 # extraConfig: |
 #   DOWNSCALE_PERIOD: "Mon-Sun 19:00-20:00 Europe/Berlin"
 extraConfig: ""
+
+# Force pod restart when the configuration changes
+forceRestartOnConfigChange: false


### PR DESCRIPTION
## Motivation

Currently, when `excludedNamespaces` or `extraConfig` are modified, the pod does not automatically reload the new configuration, requiring a manual intervention to apply the changes from the ConfigMap. This update introduces an option to trigger an automatic pod restart whenever the ConfigMap is updated. 

## Changes

- Added `forceRestartOnConfigChange` to `values.yaml`, allowing users to enable automatic pod restarts on ConfigMap changes.
- When enabled, this adds `checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}` to the Deployment, ensuring that any ConfigMap modification triggers a rollout.

## Tests done

Deployed the Helm chart in my cluster with various configurations to verify that the pod restarts as expected when the ConfigMap changes.

## TODO

- [x] I've assigned myself to this PR
