### PR TITLE
fix: move imagePullPolicy to container definition

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,5 +3,5 @@ name: py-kube-downscaler
 description: A Helm chart for deploying py-kube-downscaler
 
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "25.3.0"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,5 +3,5 @@ name: py-kube-downscaler
 description: A Helm chart for deploying py-kube-downscaler
 
 type: application
-version: 0.3.2
+version: 0.3.1
 appVersion: "25.3.0"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,5 +3,5 @@ name: py-kube-downscaler
 description: A Helm chart for deploying py-kube-downscaler
 
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "25.3.0"

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -35,9 +35,7 @@ spec:
           {{- toYaml .Values.resources | nindent 10 }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        {{- with .Values.image.pullPolicy }}
-        imagePullPolicy: {{ toYaml . }}
-        {{- end }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -35,9 +35,9 @@ spec:
           {{- toYaml .Values.resources | nindent 10 }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-      {{- with .Values.image.pullPolicy }}
-      imagePullPolicy: {{ toYaml . }}
-      {{- end }}
+        {{- with .Values.image.pullPolicy }}
+        imagePullPolicy: {{ toYaml . }}
+        {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Motivation

`imagePullPolicy` has been added to the helm chart  at the correct level of indentation. This is leading to outOfSync errors in ArgoCD. 

## Changes

Moves imagePullPolicy to the correct location in the `deployment.yaml` file of the helm chart

## Tests done

## TODO

- [x] I've assigned myself to this PR
