### PR TITLE
fix: correct imagePullPolicy indexing in deployment.yaml

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,5 +3,5 @@ name: py-kube-downscaler
 description: A Helm chart for deploying py-kube-downscaler
 
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "25.3.0"

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -40,9 +40,9 @@ spec:
           {{- toYaml .Values.resources | nindent 10 }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-      {{- with .Values.image.pullPolicy }}
-      imagePullPolicy: {{ toYaml . }}
-      {{- end }}
+        {{- with .Values.image.pullPolicy }}
+        imagePullPolicy: {{ toYaml . }}
+        {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Motivation

The` imagePullPolicy` value in `deployment.yaml` was incorrectly indexed, causing Helm to not apply the expected value from `values.yaml`. This fix ensures the correct field is referenced.

## Changes

Fixed incorrect indexing of `imagePullPolicy` in `deployment.yaml`, ensuring values are correctly referenced from `values.yaml`.

## Tests done

Tested on my own cluster deploying it with ArgoCD.

## TODO

- [ ] I've assigned myself to this PR
