### PR TITLE
Fix/Broken Helm Chart When Using Multiple Constrained Namespaces

### DIFF
--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -132,6 +132,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ $serviceAccountName }}
     namespace: {{ $releaseNamespace }}
+---
 {{- end }}
 {{- else }}
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Motivation

When using `constrainedDownscaler=true` with multiple `constrainedNamespaces` defined, the Helm Chart was unable to correctly separate Roles and RoleBindings for each namespace (#147)

## Changes

- Added a separator after the RoleBinding

## Tests done

- Built the Helm Chart in this way:

 `helm template . --set constrainedDownscaler=true --set constrainedNamespaces[0]=kube-system --set constrainedNamespaces[1]=monitoring --set constrainedNamespaces[2]=test
`
## TODO

- [x] I've assigned myself to this PR
