### PR TITLE
Fix: Behavior of Pod Disruption Budgets With Percentages

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,6 +611,16 @@ The feature to scale DaemonSets can be very useful for reducing the base occupan
 1. Downtime Hours: Kube Downscaler will add to each targeted DaemonSet a Node Selector that cannot be satisfied `kube-downscaler-non-existent=true`
 2. Uptime Hours: Kube Downscaler will remove the `kube-downscaler-non-existent=true` Node Selector from each targeted DaemonSet
 
+### Scaling PodDisruptionBudgets
+
+The feature to scale PodDisruptionBudgets can be useful to relax availability constraints on workloads. If enabled, the PodDisruptionBudget algorithm works like this:
+
+1. Downtime Hours: Kube Downscaler will bring `minAvailable` and `maxUnavailable` to 0
+2. Uptime Hours: Kube Downscaler will bring back `minAvailable` and `maxUnavailable` to their original value
+
+**Important**: Kube Downscaler, actually, cannot process values written in percentages. Resources with `minAvailable` or `maxUnavailable` written as percentages
+will be automatically excluded from scaling
+
 ### Scaling ScaledObjects
 
 The ability to downscale ScaledObjects is very useful for workloads that use Keda to support

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Scale down / "pause" Kubernetes workload (`Deployments`, `StatefulSets`,
     - [Scaling Jobs Natively](#scaling-jobs-natively)
     - [Scaling Jobs With Admission Controller](#scaling-jobs-with-admission-controller)
     - [Scaling DaemonSets](#scaling-daemonsets)
+    - [Scaling PodDisruptionBudgets](#scaling-poddisruptionbudgets)
     - [Scaling ScaledObjects](#scaling-scaledobjects)
     - [Matching Labels Argument](#matching-labels-argument)
     - [Namespace Defaults](#namespace-defaults)
@@ -618,8 +619,7 @@ The feature to scale PodDisruptionBudgets can be useful to relax availability co
 1. Downtime Hours: Kube Downscaler will bring `minAvailable` and `maxUnavailable` to 0
 2. Uptime Hours: Kube Downscaler will bring back `minAvailable` and `maxUnavailable` to their original value
 
-**Important**: Kube Downscaler, actually, cannot process values written in percentages. Resources with `minAvailable` or `maxUnavailable` written as percentages
-will be automatically excluded from scaling
+**Important**: Kube Downscaler, actually, cannot process values written in percentages. Resources with `minAvailable` or `maxUnavailable` written as percentages will be automatically excluded from scaling
 
 ### Scaling ScaledObjects
 

--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -415,7 +415,9 @@ def get_replicas(
             replicas = resource.obj["spec"]["minAvailable"]
             if "%" in str(replicas):
                 replicas = 0
-                logger.warning(f"{resource.kind} {resource.namespace}/{resource.name} has minAvailable field specified in percentage and therefore cannot be scaled")
+                logger.warning(
+                    f"{resource.kind} {resource.namespace}/{resource.name} has minAvailable field specified in percentage and therefore cannot be scaled"
+                )
             logger.debug(
                 f"{resource.kind} {resource.namespace}/{resource.name} has {replicas} minAvailable (original: {original_replicas}, uptime: {uptime})"
             )
@@ -423,7 +425,9 @@ def get_replicas(
             replicas = resource.obj["spec"]["maxUnavailable"]
             if "%" in str(replicas):
                 replicas = 0
-                logger.warning(f"{resource.kind} {resource.namespace}/{resource.name} has maxUnavailable field specified in percentage and therefore cannot be scaled")
+                logger.warning(
+                    f"{resource.kind} {resource.namespace}/{resource.name} has maxUnavailable field specified in percentage and therefore cannot be scaled"
+                )
             logger.debug(
                 f"{resource.kind} {resource.namespace}/{resource.name} has {replicas} maxUnavailable (original: {original_replicas}, uptime: {uptime})"
             )

--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -413,11 +413,17 @@ def get_replicas(
     elif resource.kind == "PodDisruptionBudget":
         if "minAvailable" in resource.obj["spec"]:
             replicas = resource.obj["spec"]["minAvailable"]
+            if "%" in str(replicas):
+                replicas = 0
+                logger.warning(f"{resource.kind} {resource.namespace}/{resource.name} has minAvailable field specified in percentage and therefore cannot be scaled")
             logger.debug(
                 f"{resource.kind} {resource.namespace}/{resource.name} has {replicas} minAvailable (original: {original_replicas}, uptime: {uptime})"
             )
         elif "maxUnavailable" in resource.obj["spec"]:
             replicas = resource.obj["spec"]["maxUnavailable"]
+            if "%" in str(replicas):
+                replicas = 0
+                logger.warning(f"{resource.kind} {resource.namespace}/{resource.name} has maxUnavailable field specified in percentage and therefore cannot be scaled")
             logger.debug(
                 f"{resource.kind} {resource.namespace}/{resource.name} has {replicas} maxUnavailable (original: {original_replicas}, uptime: {uptime})"
             )

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -2567,6 +2567,65 @@ def test_scale_down_jobs_kyverno_policy_none(objects_mock):
 
     assert operation == "scale_down"
 
+def test_scaler_pdb_suspend_percentage(monkeypatch):
+    api = MagicMock()
+    monkeypatch.setattr(
+        "kube_downscaler.scaler.helper.get_kube_api", MagicMock(return_value=api)
+    )
+    monkeypatch.setattr(
+        "kube_downscaler.scaler.helper.add_event", MagicMock(return_value=None)
+    )
+
+    def get(url, version, **kwargs):
+        if url == "pods":
+            data = {"items": []}
+        elif url == "poddisruptionbudgets":
+            data = {
+                "items": [
+                    {
+                        "metadata": {
+                            "name": "pdb-1",
+                            "namespace": "default",
+                            "creationTimestamp": "2024-02-03T16:38:00Z",
+                        },
+                        "spec": {"maxUnavailable": "10%"},
+                    },
+                ]
+            }
+        elif url == "namespaces/default":
+            data = {"metadata": {"annotations": {"downscaler/uptime": "never"}}}
+        else:
+            raise Exception(f"unexpected call: {url}, {version}, {kwargs}")
+
+        response = MagicMock()
+        response.json.return_value = data
+        return response
+
+    api.get = get
+
+    include_resources = frozenset(["poddisruptionbudgets"])
+    scale(
+        constrained_downscaler=False,
+        namespaces=[],
+        upscale_period="never",
+        downscale_period="never",
+        default_uptime="never",
+        default_downtime="always",
+        upscale_target_only=False,
+        include_resources=include_resources,
+        exclude_namespaces=[],
+        exclude_deployments=[],
+        admission_controller="",
+        dry_run=False,
+        grace_period=300,
+        api_server_timeout=10,
+        max_retries_on_conflict=0,
+        downtime_replicas=0,
+        enable_events=True,
+        matching_labels=frozenset([re.compile("")]),
+    )
+
+    assert api.patch.call_count == 0
 
 def test_scaler_pdb_suspend_max_unavailable(monkeypatch):
     api = MagicMock()

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -2567,6 +2567,7 @@ def test_scale_down_jobs_kyverno_policy_none(objects_mock):
 
     assert operation == "scale_down"
 
+
 def test_scaler_pdb_suspend_percentage(monkeypatch):
     api = MagicMock()
     monkeypatch.setattr(
@@ -2626,6 +2627,7 @@ def test_scaler_pdb_suspend_percentage(monkeypatch):
     )
 
     assert api.patch.call_count == 0
+
 
 def test_scaler_pdb_suspend_max_unavailable(monkeypatch):
     api = MagicMock()


### PR DESCRIPTION
## Motivation

As described #154, the downscaler is actually not able to handle values written as percentages such as:

```yaml
  spec:
    maxUnavailable: 10%
    selector:
      matchLabels:
        app: test-app
```

## Changes

- Displaying warning log when scaling PodDisruptionBudgets that falls in the description made above
- Improved documentation
- Added unit tests with percentage

## Tests done

- Unit Tests

## TODO

- [x] I've assigned myself to this PR
