### PR TITLE
Feat: Scale PodDisruptionBudgets With Percentage Values

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,9 +619,11 @@ The feature to scale PodDisruptionBudgets can be useful to relax availability co
 1. Downtime Hours: Kube Downscaler will bring `minAvailable` and `maxUnavailable` to downtime replicas value
 2. Uptime Hours: Kube Downscaler will bring back `minAvailable` and `maxUnavailable` to their original value
 
-**Important**: Kube Downscaler can process PodDisruptionBudgets with `minAvailable` or `maxUnavailable` specified as a percentage only if
-either the global argument `--downtime-replicas` or the namespace/workload annotation `downscaler/downtime-replicas` is set to a value greater than 0.
-Otherwise the resource will be ignored
+**Important**: Kube Downscaler can process PodDisruptionBudgets with `minAvailable` or `maxUnavailable`. In this case, during downtime hours, the following behavior applies:
+  1. The `downscaler/original-replicas` annotation will store the original percentage value (e.g., "75%") as a string. 
+  2. The `minAvailable`/`maxUnavailable` field of the object will be updated to the target downtime replicas value (e.g., 0) as an integer.
+
+The original percentage value in the `minAvailable`/`maxUnavailable` field will be restored once the downtime hours end
 
 ### Scaling ScaledObjects
 

--- a/README.md
+++ b/README.md
@@ -623,6 +623,8 @@ The feature to scale PodDisruptionBudgets can be useful to relax availability co
   1. The `downscaler/original-replicas` annotation will store the original percentage value (e.g., "75%") as a string. 
   2. The `minAvailable`/`maxUnavailable` field of the object will be updated to the target downtime replicas value (e.g., 0) as an integer.
 
+Only for PodDisruptionBudgets `downscaler/donwtime-replicas` supports a percentage value
+
 The original percentage value in the `minAvailable`/`maxUnavailable` field will be restored once the downtime hours end
 
 ### Scaling ScaledObjects

--- a/README.md
+++ b/README.md
@@ -630,7 +630,7 @@ The original percentage value in the `minAvailable`/`maxUnavailable` field will 
 annotation `downscaler/donwtime-replicas` (e.g. `--donwtime-replicas="20%"` or `downscaler/donwtime-replicas: "10%"`)
   - If `--include-resources` scales PodDisruptionBudgets and other resources, using a percentage value inside the global argument value `--downtime-replicas` or as a namespace
 annotation `downscaler/donwtime-replicas` will result in all other resources under its scope being ignored (e.g. if you set `--downtime-replicas="10%"` all resources inside the cluster other than PodDisruptionBudgets will be ignored,
-if you set `downscaler/donwtime-replicas: "10%"` at namespace level, all resources other tan PodDisruptionBudgets in that namespace will be ignored)
+if you set `downscaler/donwtime-replicas: "10%"` at namespace level, all resources other than PodDisruptionBudgets in that namespace will be ignored)
 ### Scaling ScaledObjects
 
 The ability to downscale ScaledObjects is very useful for workloads that use Keda to support

--- a/README.md
+++ b/README.md
@@ -616,10 +616,12 @@ The feature to scale DaemonSets can be very useful for reducing the base occupan
 
 The feature to scale PodDisruptionBudgets can be useful to relax availability constraints on workloads. If enabled, the PodDisruptionBudget algorithm works like this:
 
-1. Downtime Hours: Kube Downscaler will bring `minAvailable` and `maxUnavailable` to 0
+1. Downtime Hours: Kube Downscaler will bring `minAvailable` and `maxUnavailable` to downtime replicas value
 2. Uptime Hours: Kube Downscaler will bring back `minAvailable` and `maxUnavailable` to their original value
 
-**Important**: Kube Downscaler, actually, cannot process values written in percentages. Resources with `minAvailable` or `maxUnavailable` written as percentages will be automatically excluded from scaling
+**Important**: Kube Downscaler can process PodDisruptionBudgets with `minAvailable` or `maxUnavailable` specified as a percentage only if
+either the global argument `--downtime-replicas` or the namespace/workload annotation `downscaler/downtime-replicas` is set to a value greater than 0.
+Otherwise the resource will be ignored
 
 ### Scaling ScaledObjects
 

--- a/README.md
+++ b/README.md
@@ -619,14 +619,18 @@ The feature to scale PodDisruptionBudgets can be useful to relax availability co
 1. Downtime Hours: Kube Downscaler will bring `minAvailable` and `maxUnavailable` to downtime replicas value
 2. Uptime Hours: Kube Downscaler will bring back `minAvailable` and `maxUnavailable` to their original value
 
-**Important**: Kube Downscaler can process PodDisruptionBudgets with `minAvailable` or `maxUnavailable`. In this case, during downtime hours, the following behavior applies:
+**Percentage Values**: Kube Downscaler can process PodDisruptionBudgets with `minAvailable` or `maxUnavailable`. In this case, during downtime hours, the following behavior applies:
   1. The `downscaler/original-replicas` annotation will store the original percentage value (e.g., "75%") as a string. 
   2. The `minAvailable`/`maxUnavailable` field of the object will be updated to the target downtime replicas value (e.g., 0) as an integer.
 
-Only for PodDisruptionBudgets `downscaler/donwtime-replicas` supports a percentage value
-
 The original percentage value in the `minAvailable`/`maxUnavailable` field will be restored once the downtime hours end
 
+**Downtime Replicas**: Kube Downscaler can process downtime replicas specified as a percentage. The behavior will be the following:
+  - If `--include-resources` only scales PodDisruptionBudgets, the value assigned to downtime replicas can be set as a percentage inside the global argument value `--downtime-replicas` or as a namespace/workload
+annotation `downscaler/donwtime-replicas` (e.g. `--donwtime-replicas="20%"` or `downscaler/donwtime-replicas: "10%"`)
+  - If `--include-resources` scales PodDisruptionBudgets and other resources, using a percentage value inside the global argument value `--downtime-replicas` or as a namespace
+annotation `downscaler/donwtime-replicas` will result in all other resources under its scope being ignored (e.g. if you set `--downtime-replicas="10%"` all resources inside the cluster other than PodDisruptionBudgets will be ignored,
+if you set `downscaler/donwtime-replicas: "10%"` at namespace level, all resources other tan PodDisruptionBudgets in that namespace will be ignored)
 ### Scaling ScaledObjects
 
 The ability to downscale ScaledObjects is very useful for workloads that use Keda to support

--- a/kube_downscaler/cmd.py
+++ b/kube_downscaler/cmd.py
@@ -110,9 +110,9 @@ def get_parser():
     )
     parser.add_argument(
         "--downtime-replicas",
-        type=int,
-        help="Default amount of replicas when downscaling (default: 0)",
-        default=int(os.getenv("DOWNTIME_REPLICAS", 0)),
+        type=str,
+        help="Default value used when downscaling (default: '0')",
+        default=os.getenv("DOWNTIME_REPLICAS", "0"),
     )
     parser.add_argument(
         "--deployment-time-annotation",

--- a/kube_downscaler/helper.py
+++ b/kube_downscaler/helper.py
@@ -28,7 +28,7 @@ def matches_time_spec(time: datetime.datetime, spec: str):
         spec_ = spec_.strip()
         recurring_match = TIME_SPEC_PATTERN.match(spec_)
         if recurring_match is not None and _matches_recurring_time_spec(
-                time, recurring_match
+            time, recurring_match
         ):
             return True
         absolute_match = ABSOLUTE_TIME_SPEC_PATTERN.match(spec_)

--- a/kube_downscaler/helper.py
+++ b/kube_downscaler/helper.py
@@ -28,7 +28,7 @@ def matches_time_spec(time: datetime.datetime, spec: str):
         spec_ = spec_.strip()
         recurring_match = TIME_SPEC_PATTERN.match(spec_)
         if recurring_match is not None and _matches_recurring_time_spec(
-            time, recurring_match
+                time, recurring_match
         ):
             return True
         absolute_match = ABSOLUTE_TIME_SPEC_PATTERN.match(spec_)
@@ -69,6 +69,30 @@ def get_kube_api(timeout: int):
     config = pykube.KubeConfig.from_env()
     api = pykube.HTTPClient(config, timeout=timeout)
     return api
+
+
+def parse_int_or_percent(value, context, allow_negative):
+    s = str(value).strip()
+
+    if s.endswith("%"):
+        number_part = s[:-1].strip()
+        if number_part.isdigit():
+            val = int(number_part)
+            if 0 <= val <= 100:
+                return val, True
+            else:
+                raise ValueError(f"Percentage in {context} must be between 0 and 100.")
+        else:
+            raise ValueError(f"Invalid percentage format in {context}: must be digits before '%'.")
+
+    if allow_negative:
+        if (s.startswith("-") and s[1:].isdigit()) or s.isdigit():
+            return int(s), False
+    else:
+        if s.isdigit():
+            return int(s), False
+
+    raise ValueError(f"Invalid format for {context}: must be an integer like '10' or a percentage like '10%'.")
 
 
 def add_event(resource, message: str, reason: str, event_type: str, dry_run: bool):

--- a/kube_downscaler/main.py
+++ b/kube_downscaler/main.py
@@ -7,25 +7,14 @@ from kube_downscaler import __version__
 from kube_downscaler import cmd
 from kube_downscaler import shutdown
 from kube_downscaler.scaler import scale
+from kube_downscaler import helper
 
 logger = logging.getLogger("downscaler")
 
 
 def parse_downtime_replicas(downtime_replicas):
-    s = str(downtime_replicas).strip()
-
-    match = re.fullmatch(r'(\d{1,3})%', s)
-    if match:
-        value = int(match.group(1))
-        if 0 <= value <= 100:
-            return value, True
-        else:
-            raise ValueError("Percentage must be between 0 and 100.")
-
-    if s.isdigit():
-        return int(s), False
-
-    raise ValueError("Invalid format: must be an integer like '10' or a percentage like '10%'.")
+    value, is_percentage = helper.parse_int_or_percent(downtime_replicas, context="--downtime-replicas", allow_negative=False)
+    return value, is_percentage
 
 def main(args=None):
     parser = cmd.get_parser()

--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -668,19 +668,25 @@ def scale_up(
         if "minAvailable" in resource.obj["spec"]:
             if original_replicas_type is float:
                 resource.obj["spec"]["minAvailable"] = f"{original_replicas * 100:.0f}%"
+                logger.info(
+                    f"Scaling up {resource.kind} {resource.namespace}/{resource.name} from {replicas}% to {original_replicas * 100:.0f}% minAvailable (uptime: {uptime}, downtime: {downtime})"
+                )
             else:
                 resource.obj["spec"]["minAvailable"] = original_replicas
-            logger.info(
-                f"Scaling up {resource.kind} {resource.namespace}/{resource.name} from {replicas} to {original_replicas} minAvailable (uptime: {uptime}, downtime: {downtime})"
-            )
+                logger.info(
+                    f"Scaling up {resource.kind} {resource.namespace}/{resource.name} from {replicas} to {original_replicas} minAvailable (uptime: {uptime}, downtime: {downtime})"
+                )
         elif "maxUnavailable" in resource.obj["spec"]:
             if original_replicas_type is float:
                 resource.obj["spec"]["maxUnavailable"] = f"{original_replicas * 100:.0f}%"
+                logger.info(
+                    f"Scaling up {resource.kind} {resource.namespace}/{resource.name} from {replicas}% to {original_replicas * 100:.0f}% maxUnavailable (uptime: {uptime}, downtime: {downtime})"
+                )
             else:
                 resource.obj["spec"]["maxUnavailable"] = original_replicas
-            logger.info(
-                f"Scaling up {resource.kind} {resource.namespace}/{resource.name} from {replicas} to {original_replicas} maxUnavailable (uptime: {uptime}, downtime: {downtime})"
-            )
+                logger.info(
+                    f"Scaling up {resource.kind} {resource.namespace}/{resource.name} from {replicas} to {original_replicas} maxUnavailable (uptime: {uptime}, downtime: {downtime})"
+                )
     elif resource.kind == "HorizontalPodAutoscaler":
         resource.obj["spec"]["minReplicas"] = original_replicas
         logger.info(
@@ -759,7 +765,7 @@ def scale_down(
             resource.obj["spec"]["minAvailable"] = target_replicas
             if type is float:
                 logger.info(
-                    f"Scaling down {resource.kind} {resource.namespace}/{resource.name} from {replicas} to {target_replicas}% minAvailable (uptime: {uptime}, downtime: {downtime})"
+                    f"Scaling down {resource.kind} {resource.namespace}/{resource.name} from {replicas * 100:.0f}% to {target_replicas}% minAvailable (uptime: {uptime}, downtime: {downtime})"
                 )
             else:
                 logger.info(
@@ -769,7 +775,7 @@ def scale_down(
             resource.obj["spec"]["maxUnavailable"] = target_replicas
             if type is float:
                 logger.info(
-                    f"Scaling down {resource.kind} {resource.namespace}/{resource.name} from {replicas} to {target_replicas}% maxUnavailable (uptime: {uptime}, downtime: {downtime})"
+                    f"Scaling down {resource.kind} {resource.namespace}/{resource.name} from {replicas * 100:.0f}% to {target_replicas}% maxUnavailable (uptime: {uptime}, downtime: {downtime})"
                 )
             else:
                 logger.info(

--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -838,7 +838,7 @@ def get_annotation_value_as_positive_int(
 ):
     raw_value = resource.annotations.get(annotation_name)
     if raw_value is None:
-        return None, False
+        return None, None
     return helper.parse_int_or_percent(raw_value, context="annotation", allow_negative=False)
 
 def get_annotation_value_as_int(
@@ -846,7 +846,7 @@ def get_annotation_value_as_int(
 ):
     raw_value = resource.annotations.get(annotation_name)
     if raw_value is None:
-        return None, False
+        return None, None
     return helper.parse_int_or_percent(raw_value, context="annotation", allow_negative=True)
 
 def autoscale_jobs_for_namespace(
@@ -1020,7 +1020,6 @@ def autoscale_resource(
         downtime_replicas_from_annotation, is_downtime_replicas_from_annotation_percentage = get_annotation_value_as_positive_int(
             resource, DOWNTIME_REPLICAS_ANNOTATION
         )
-
 
         if downtime_replicas_from_annotation is not None:
             downtime_replicas = downtime_replicas_from_annotation

--- a/tests/test_autoscale_resource.py
+++ b/tests/test_autoscale_resource.py
@@ -500,8 +500,7 @@ def test_downtime_replicas_annotation_invalid(resource, monkeypatch):
         now=now,
         matching_labels=frozenset([re.compile("")]),
     )
-    assert resource.replicas == 2
-    resource.update.assert_not_called()
+    assert resource.replicas == 0
 
 
 def test_downtime_replicas_annotation_valid(resource, monkeypatch):
@@ -1116,6 +1115,46 @@ def test_downscale_hpa_with_autoscaling(monkeypatch):
     )
     assert hpa.obj["spec"]["minReplicas"] == 1
     assert hpa.obj["metadata"]["annotations"][ORIGINAL_REPLICAS_ANNOTATION] == str(4)
+
+def test_downscale_hpa_wrong_annotation_value_with_autoscaling(monkeypatch):
+    api = MagicMock()
+    monkeypatch.setattr(
+        "kube_downscaler.scaler.helper.get_kube_api", MagicMock(return_value=api)
+    )
+    hpa = HorizontalPodAutoscaler(
+        None,
+        {
+            "metadata": {
+                "name": "my-hpa",
+                "namespace": "my-ns",
+                "creationTimestamp": "2018-10-23T21:55:00Z",
+                "annotations": {DOWNTIME_REPLICAS_ANNOTATION: "3%"},
+            },
+            "spec": {"minReplicas": 4},
+        },
+    )
+    now = datetime.strptime("2018-10-23T21:56:00Z", "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=timezone.utc
+    )
+    autoscale_resource(
+        hpa,
+        upscale_target_only=False,
+        upscale_period="never",
+        downscale_period="never",
+        default_uptime="never",
+        default_downtime="always",
+        forced_uptime=False,
+        forced_downtime=False,
+        dry_run=True,
+        max_retries_on_conflict=0,
+        api=api,
+        kind=HorizontalPodAutoscaler,
+        now=now,
+        matching_labels=frozenset([re.compile("")]),
+    )
+
+    #if the DOWNTIME_REPLICAS_ANNOTATION has a percentage value on non pdb objects, they will be skipped
+    assert hpa.obj["spec"]["minReplicas"] == 4
 
 
 def test_upscale_hpa_with_autoscaling(monkeypatch):

--- a/tests/test_autoscale_resource.py
+++ b/tests/test_autoscale_resource.py
@@ -500,7 +500,8 @@ def test_downtime_replicas_annotation_invalid(resource, monkeypatch):
         now=now,
         matching_labels=frozenset([re.compile("")]),
     )
-    assert resource.replicas == 0
+    assert resource.replicas == 2
+    resource.update.assert_not_called()
 
 
 def test_downtime_replicas_annotation_valid(resource, monkeypatch):

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -505,7 +505,6 @@ def test_scaler_down_to(monkeypatch):
     assert api.patch.call_args[1]["url"] == "/deployments/deploy-1"
     assert json.loads(api.patch.call_args[1]["data"])["spec"]["replicas"] == SCALE_TO
 
-
 def test_scaler_down_to_upscale(monkeypatch):
     api = MagicMock()
     monkeypatch.setattr(

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -2694,7 +2694,7 @@ def test_scaler_pdb_suspend_max_unavailable_percentage(monkeypatch):
             "name": "pdb-1",
             "namespace": "default",
             "creationTimestamp": "2024-02-03T16:38:00Z",
-            "annotations": {ORIGINAL_REPLICAS_ANNOTATION: "0.1"},
+            "annotations": {ORIGINAL_REPLICAS_ANNOTATION: "10%"},
         },
         "spec": {"maxUnavailable": 0},
     }
@@ -2720,7 +2720,7 @@ def test_scaler_pdb_unsuspend_max_unavailable_percentage(monkeypatch):
                             "name": "pdb-1",
                             "namespace": "default",
                             "creationTimestamp": "2024-02-03T16:38:00Z",
-                            "annotations": {ORIGINAL_REPLICAS_ANNOTATION: "0.1"},
+                            "annotations": {ORIGINAL_REPLICAS_ANNOTATION: "1%"},
                         },
                         "spec": {"maxUnavailable": 0},
                     },
@@ -2776,7 +2776,7 @@ def test_scaler_pdb_unsuspend_max_unavailable_percentage(monkeypatch):
             "creationTimestamp": "2024-02-03T16:38:00Z",
             "annotations": {ORIGINAL_REPLICAS_ANNOTATION: None},
         },
-        "spec": {"maxUnavailable": "10%"},
+        "spec": {"maxUnavailable": "1%"},
     }
     assert json.loads(api.patch.call_args[1]["data"]) == patch_data
 

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -505,6 +505,131 @@ def test_scaler_down_to(monkeypatch):
     assert api.patch.call_args[1]["url"] == "/deployments/deploy-1"
     assert json.loads(api.patch.call_args[1]["data"])["spec"]["replicas"] == SCALE_TO
 
+def test_skip_deployment_with_local_downtime_replicas_percentage(monkeypatch):
+    api = MagicMock()
+    monkeypatch.setattr(
+        "kube_downscaler.scaler.helper.get_kube_api", MagicMock(return_value=api)
+    )
+    monkeypatch.setattr(
+        "kube_downscaler.scaler.helper.add_event", MagicMock(return_value=None)
+    )
+
+    def get(url, version, **kwargs):
+        if url == "pods":
+            data = {"items": []}
+        elif url == "deployments":
+            data = {
+                "items": [
+                    {
+                        "metadata": {
+                            "name": "deploy-1",
+                            "namespace": "default",
+                            "creationTimestamp": "2019-03-01T16:38:00Z",
+                            "annotations": {DOWNTIME_REPLICAS_ANNOTATION: "1%"},
+                        },
+                        "spec": {"replicas": 5},
+                    },
+                ]
+            }
+        elif url == "namespaces/default":
+            data = {"metadata": {}}
+        else:
+            raise Exception(f"unexpected call: {url}, {version}, {kwargs}")
+
+        response = MagicMock()
+        response.json.return_value = data
+        return response
+
+    api.get = get
+
+    include_resources = frozenset(["deployments"])
+    scale(
+        constrained_downscaler=False,
+        namespaces=[],
+        upscale_period="never",
+        downscale_period="never",
+        default_uptime="never",
+        default_downtime="always",
+        upscale_target_only=False,
+        include_resources=include_resources,
+        exclude_namespaces=[],
+        exclude_deployments=[],
+        matching_labels=frozenset([re.compile("")]),
+        dry_run=False,
+        grace_period=300,
+        admission_controller="",
+        api_server_timeout=10,
+        max_retries_on_conflict=0,
+        downtime_replicas=0,
+        is_downtime_replicas_percentage=False,
+        enable_events=True,
+    )
+
+    #it is not possible to use downscaler/downtime-replicas with percentage values to scale resources other than pdb
+    assert api.patch.call_count == 0
+
+def test_skip_deployment_with_global_downtime_replicas_percentage(monkeypatch):
+    api = MagicMock()
+    monkeypatch.setattr(
+        "kube_downscaler.scaler.helper.get_kube_api", MagicMock(return_value=api)
+    )
+    monkeypatch.setattr(
+        "kube_downscaler.scaler.helper.add_event", MagicMock(return_value=None)
+    )
+
+    def get(url, version, **kwargs):
+        if url == "pods":
+            data = {"items": []}
+        elif url == "deployments":
+            data = {
+                "items": [
+                    {
+                        "metadata": {
+                            "name": "deploy-1",
+                            "namespace": "default",
+                            "creationTimestamp": "2019-03-01T16:38:00Z",
+                        },
+                        "spec": {"replicas": 5},
+                    },
+                ]
+            }
+        elif url == "namespaces/default":
+            data = {"metadata": {}}
+        else:
+            raise Exception(f"unexpected call: {url}, {version}, {kwargs}")
+
+        response = MagicMock()
+        response.json.return_value = data
+        return response
+
+    api.get = get
+
+    include_resources = frozenset(["deployments"])
+    scale(
+        constrained_downscaler=False,
+        namespaces=[],
+        upscale_period="never",
+        downscale_period="never",
+        default_uptime="never",
+        default_downtime="always",
+        upscale_target_only=False,
+        include_resources=include_resources,
+        exclude_namespaces=[],
+        exclude_deployments=[],
+        matching_labels=frozenset([re.compile("")]),
+        dry_run=False,
+        grace_period=300,
+        admission_controller="",
+        api_server_timeout=10,
+        max_retries_on_conflict=0,
+        downtime_replicas=0,
+        is_downtime_replicas_percentage=True,
+        enable_events=True,
+    )
+
+    #if global --downtime-replicas is a percentage, it is not possible to scale resources other than pdb
+    assert api.patch.call_count == 0
+
 def test_scaler_down_to_upscale(monkeypatch):
     api = MagicMock()
     monkeypatch.setattr(


### PR DESCRIPTION
## Motivation

As addressed in the issue #159 actually KubeDownscaler is not able to scale PodDisruptionBudgets with fields specified as a percentage. This PR aims at fixing this limitation

## Changes

- The main algorithm is now able to distinguish and process both float and integer values
- `get_replicas`, `scale_up` and `scale_down` functions are now able to process float values
- Improved documentation

Limitation: even though PodDisruptionBudgets can now be processed if they have fields specified as a percentage, if either the global argument --downtime-replicas or the workload/namespace annotation downscaler/downtime-replicas is set to a value greater than 0, the resource will be excluded. This is because the percentage is converted to a float value `0<=x<=1`

## Tests done

- Refactored UnitTests

## TODO

- [x] I've assigned myself to this PR
