### PR TITLE
Improve hlem chart options

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
     metadata:
       labels:
         {{- include "py-kube-downscaler.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- if or .Values.podAnnotations .Values.forceRestartOnConfigChange }}
       annotations:
         {{- if .Values.forceRestartOnConfigChange }}
@@ -37,6 +40,10 @@ spec:
         - configMapRef:
             name: {{ .Values.configMapName }}
             optional: true
+        env:
+        {{- with .Values.extraEnv }}
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         securityContext:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -75,3 +75,10 @@ extraConfig: ""
 
 # Force pod restart when the configuration changes
 forceRestartOnConfigChange: true
+
+# Optional pod labels
+podLabels: {}
+
+# Optional additional environment variables injected into the container
+# This is especially useful for observability tools
+extraEnv: []


### PR DESCRIPTION
## Motivation


This change introduces support for injecting additional pod-level metadata and container-level environment variables through the `values.yaml` file. This is especially useful for integrating observability tools like Datadog, where custom labels (`tags.datadoghq.com/*`) and environment variables (`DD_ENV`, `DD_SERVICE`, etc.) are required for metrics, logs, and APM trace enrichment.

Adding this support makes the chart more flexible and consistent with Helm chart best practices, without introducing breaking changes.


## Changes


- Added support for `.Values.podLabels` in the `Deployment` template  
  → Allows injection of Kubernetes labels at the pod level (e.g. Datadog tags)

- Added support for `.Values.extraEnv` in the `Deployment` template  
  → Allows dynamic injection of environment variables into the container

- Updated default `values.yaml` with empty defaults:
  ```yaml
  podLabels: {}
  extraEnv: []

## Tests done

<!--
List the tests that were done to verify the changes.
-->

## TODO

- [x] I've assigned myself to this PR
