### PR TITLE
chore: release new helm chart version for app version 25.8.0

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,5 +3,5 @@ name: py-kube-downscaler
 description: A Helm chart for deploying py-kube-downscaler
 
 type: application
-version: 0.3.5
-appVersion: "25.7.0"
+version: 0.3.6
+appVersion: "25.8.0"


### PR DESCRIPTION
## Changes

Update helm chart version and reference new app version. See https://github.com/caas-team/py-kube-downscaler/pull/168
