### PR TITLE
Feat: Introduce Argument To Enable Json Logs

### DIFF
--- a/kube_downscaler/cmd.py
+++ b/kube_downscaler/cmd.py
@@ -134,4 +134,9 @@ def get_parser():
         default=os.getenv("ADMISSION_CONTROLLER", ""),
         help="Apply downscaling to jobs using the supplied admission controller. Jobs should be included inside --include-resources if you want to use this parameter. kyverno and gatekeeper are supported.",
     )
+    parser.add_argument(
+        "--json-logs",
+        help="Output logs in JSON format instead of plain text (default: false)",
+        action="store_true",
+    )
     return parser

--- a/kube_downscaler/helper.py
+++ b/kube_downscaler/helper.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import logging
 import re
 import sys
@@ -159,15 +160,22 @@ def create_event(resource, message: str, reason: str, event_type: str, dry_run: 
         except Exception as e:
             logger.error(f"Could not create event {event.obj}: {e}")
 
-def setup_logging(debug: bool):
+def setup_logging(debug: bool, json_logs: bool):
     logging.getLogger().handlers.clear()
-
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.DEBUG if debug else logging.INFO)
 
-    formatter = logging.Formatter("%(asctime)s %(levelname)s: %(message)s")
-
     stderr_handler = logging.StreamHandler(sys.stderr)
-    stderr_handler.setFormatter(formatter)
 
+    if json_logs:
+        formatter = logging.Formatter()
+        formatter.format = lambda record: json.dumps({
+            "time": logging.Formatter.formatTime(logging.Formatter(), record),
+            "severity": record.levelname,
+            "message": record.getMessage().replace('"', "'")
+        })
+    else:
+        formatter = logging.Formatter("%(asctime)s %(levelname)s: %(message)s")
+
+    stderr_handler.setFormatter(formatter)
     root_logger.addHandler(stderr_handler)

--- a/kube_downscaler/main.py
+++ b/kube_downscaler/main.py
@@ -20,7 +20,7 @@ def main(args=None):
     parser = cmd.get_parser()
     args = parser.parse_args(args)
 
-    helper.setup_logging(args.debug)
+    helper.setup_logging(args.debug, args.json_logs)
 
     config_str = ", ".join(f"{k}={v}" for k, v in sorted(vars(args).items()))
     logger.info(f"Downscaler v{__version__} started with {config_str}")


### PR DESCRIPTION
## Motivation

This PR fixes #177 and enables the possibility to output logs to JSON format.

Since the name of the field associated to the log level is called "severity", which is compatible with GCP standards for logging, this PR also helps to correctly handle logs severity in GCP

## Changes

- Introduced an optional argument `--json-logs` that enables the user to output logs in JSON format.

## Tests done

- Live Tests

## TODO

- [x] I've assigned myself to this PR
