### PR TITLE
feat(chart): add support for startup, liveness and readiness probes

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -50,6 +50,18 @@ spec:
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -49,6 +49,17 @@ securityContext:
   capabilities:
     drop:
       - ALL
+# Optional health probes for the controller container.
+# Note: this controller doesn't serve HTTP traffic by default, so exec probes are usually the best option.
+# Example:
+# livenessProbe:
+#   exec:
+#     command: ["/bin/sh", "-c", "ps aux | grep -v grep | grep -q kube-downscaler"]
+#   initialDelaySeconds: 30
+#   periodSeconds: 10
+startupProbe: {}
+livenessProbe: {}
+readinessProbe: {}
 
 resources:
   limits:


### PR DESCRIPTION
## Motivation

The Helm chart currently does not expose any configuration options for Kubernetes health probes.

Adding optional support for startupProbe, livenessProbe and readinessProbe allows users to follow Kubernetes best practices and better integrate the deployment with monitoring and observability tooling, while keeping the default behavior unchanged.

The probes are fully optional and disabled by default, so existing users are not impacted.


## Changes


Added optional support for startupProbe, livenessProbe and readinessProbe in the Deployment template

Documented the new values in values.yaml

No default values were changed


## Tests done

helm lint

helm template

Manual deployment in a test Kubernetes cluster using exec-based probes


## TODO

-  I've assigned myself to this PR
